### PR TITLE
feat: add CorrelationMiddleware and GetRequestID

### DIFF
--- a/correlation.go
+++ b/correlation.go
@@ -1,0 +1,53 @@
+package promolog
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+)
+
+// GetRequestID retrieves the request ID from the context, or returns
+// an empty string if none is set.
+func GetRequestID(ctx context.Context) string {
+	if id, ok := ctx.Value(RequestIDKey).(string); ok {
+		return id
+	}
+	return ""
+}
+
+// generateID produces a 32-character hex-encoded random request ID.
+func generateID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(b)
+}
+
+// CorrelationMiddleware is stdlib HTTP middleware that sets up per-request
+// correlation for promolog. It generates a unique request ID (or reuses one
+// from the incoming X-Request-ID header), sets the X-Request-ID response
+// header, stores the ID in the request context, and initializes a promolog
+// Buffer for log capture.
+//
+// Usage with net/http:
+//
+//	mux := http.NewServeMux()
+//	http.ListenAndServe(":8080", promolog.CorrelationMiddleware(mux))
+//
+// Usage with Echo:
+//
+//	e.Use(echo.WrapMiddleware(promolog.CorrelationMiddleware))
+func CorrelationMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestID := r.Header.Get("X-Request-ID")
+		if requestID == "" {
+			requestID = generateID()
+		}
+		w.Header().Set("X-Request-ID", requestID)
+		ctx := context.WithValue(r.Context(), RequestIDKey, requestID)
+		ctx = NewBufferContext(ctx)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/correlation_test.go
+++ b/correlation_test.go
@@ -1,0 +1,100 @@
+package promolog
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCorrelationMiddleware_GeneratesRequestID(t *testing.T) {
+	handler := CorrelationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := GetRequestID(r.Context())
+		assert.NotEmpty(t, id)
+		assert.Len(t, id, 32) // 16 bytes hex-encoded
+
+		buf := GetBuffer(r.Context())
+		assert.NotNil(t, buf)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.NotEmpty(t, rec.Header().Get("X-Request-ID"))
+	assert.Len(t, rec.Header().Get("X-Request-ID"), 32)
+}
+
+func TestCorrelationMiddleware_ReusesIncomingRequestID(t *testing.T) {
+	incoming := "abc-from-load-balancer-123"
+
+	var captured string
+	handler := CorrelationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = GetRequestID(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Request-ID", incoming)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, incoming, captured)
+	assert.Equal(t, incoming, rec.Header().Get("X-Request-ID"))
+}
+
+func TestCorrelationMiddleware_InitializesBuffer(t *testing.T) {
+	handler := CorrelationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := GetBuffer(r.Context())
+		require.NotNil(t, buf)
+
+		buf.Append(Entry{Level: "INFO", Message: "test"})
+		assert.Len(t, buf.Snapshot(), 1)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestCorrelationMiddleware_CallsNext(t *testing.T) {
+	called := false
+	handler := CorrelationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusTeapot, rec.Code)
+}
+
+func TestGetRequestID_EmptyWithoutMiddleware(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	assert.Empty(t, GetRequestID(req.Context()))
+}
+
+func TestGenerateID_Length(t *testing.T) {
+	id := generateID()
+	assert.Len(t, id, 32)
+}
+
+func TestGenerateID_Unique(t *testing.T) {
+	ids := make(map[string]bool)
+	for range 100 {
+		id := generateID()
+		assert.False(t, ids[id], "duplicate ID generated")
+		ids[id] = true
+	}
+}

--- a/promolog.go
+++ b/promolog.go
@@ -15,7 +15,9 @@ import (
 var ErrDuplicateTrace = errors.New("promolog: duplicate request ID")
 
 // RequestIDKey is the context key used to associate a request ID with a context.
-// Set this in your middleware: context.WithValue(ctx, promolog.RequestIDKey, "req-123")
+// CorrelationMiddleware sets this automatically. For custom setups:
+//
+//	ctx = context.WithValue(ctx, promolog.RequestIDKey, "req-123")
 type requestIDKeyType struct{}
 
 var RequestIDKey = requestIDKeyType{}


### PR DESCRIPTION
## Summary

- Add `CorrelationMiddleware` — stdlib `http.Handler` middleware that sets up per-request correlation (request ID + buffer) in one call
- Add `GetRequestID(ctx)` helper — extracts the request ID from context without consumers needing to know the context key
- Middleware reuses incoming `X-Request-ID` header from reverse proxies/load balancers, or generates a new one

## Motivation

Previously every consumer had to manually:
1. Generate a request ID
2. Store it with `context.WithValue(ctx, promolog.RequestIDKey, id)`
3. Call `promolog.NewBufferContext(ctx)`
4. Set the `X-Request-ID` response header

This is now a one-liner: `promolog.CorrelationMiddleware(handler)` or `echo.WrapMiddleware(promolog.CorrelationMiddleware)`.

The composable parts (`RequestIDKey`, `NewBufferContext`, `GetBuffer`) remain exported for custom setups.

## Test plan

- [x] `TestCorrelationMiddleware_GeneratesRequestID` — generates 32-char hex ID, sets header, stores in context
- [x] `TestCorrelationMiddleware_ReusesIncomingRequestID` — preserves X-Request-ID from upstream
- [x] `TestCorrelationMiddleware_InitializesBuffer` — buffer is appendable immediately
- [x] `TestCorrelationMiddleware_CallsNext` — passes through to wrapped handler
- [x] `TestGetRequestID_EmptyWithoutMiddleware` — returns empty without setup
- [x] `TestGenerateID_Length` / `TestGenerateID_Unique` — ID generation correctness
- [x] All 66 existing tests still pass