### PR TITLE
fix: resolve open correctness issues #49-#52

### DIFF
--- a/autopromote.go
+++ b/autopromote.go
@@ -86,16 +86,18 @@ func promoteFromRequest(store Storer, r *http.Request, statusCode int) {
 	}
 
 	trace := Trace{
-		RequestID:    requestID,
-		StatusCode:   statusCode,
-		Route:        r.URL.Path,
-		Method:       r.Method,
-		UserAgent:    r.UserAgent(),
-		RemoteIP:     r.RemoteAddr,
-		Entries:      buf.Entries(),
-		RequestBody:  buf.RequestBody(),
-		ResponseBody: buf.ResponseBody(),
-		CreatedAt:    time.Now(),
+		RequestID:       requestID,
+		ParentRequestID: GetParentRequestID(ctx),
+		StatusCode:      statusCode,
+		Route:           r.URL.Path,
+		Method:          r.Method,
+		UserAgent:       r.UserAgent(),
+		RemoteIP:        r.RemoteAddr,
+		Tags:            buf.Tags(),
+		Entries:         buf.Entries(),
+		RequestBody:     buf.RequestBody(),
+		ResponseBody:    buf.ResponseBody(),
+		CreatedAt:       time.Now(),
 	}
 
 	// Best-effort promotion; errors are intentionally ignored because the

--- a/autopromote.go
+++ b/autopromote.go
@@ -1,12 +1,17 @@
 package promolog
 
 import (
+	"bufio"
+	"net"
 	"net/http"
 	"time"
 )
 
 // responseWriter wraps http.ResponseWriter to capture the status code written
-// by the downstream handler.
+// by the downstream handler. It is never returned directly to downstream
+// handlers — one of the wrap* variants below is returned instead so that the
+// exported wrapper's method set matches the optional interfaces supported by
+// the underlying writer (http.Flusher, http.Hijacker).
 type responseWriter struct {
 	http.ResponseWriter
 	statusCode int
@@ -35,6 +40,68 @@ func (rw *responseWriter) Unwrap() http.ResponseWriter {
 	return rw.ResponseWriter
 }
 
+// The rw* variants below preserve the exact optional-interface method set of
+// the wrapped writer. Each embeds *responseWriter (so WriteHeader/Write/Unwrap
+// are inherited) and adds methods for the optional interfaces supported by the
+// underlying writer. Defining these methods unconditionally on responseWriter
+// itself would cause false-positive type assertions — e.g. a handler would
+// think the writer implements http.Flusher even when the underlying writer
+// does not, and calling Flush would panic or silently no-op.
+
+// rwFlusher forwards http.Flusher.
+type rwFlusher struct {
+	*responseWriter
+}
+
+func (r rwFlusher) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// rwHijacker forwards http.Hijacker.
+type rwHijacker struct {
+	*responseWriter
+}
+
+func (r rwHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return r.ResponseWriter.(http.Hijacker).Hijack()
+}
+
+// rwFlushHijacker forwards both http.Flusher and http.Hijacker.
+type rwFlushHijacker struct {
+	*responseWriter
+}
+
+func (r rwFlushHijacker) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (r rwFlushHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return r.ResponseWriter.(http.Hijacker).Hijack()
+}
+
+// wrapResponseWriter returns an http.ResponseWriter whose method set matches
+// the optional interfaces (http.Flusher, http.Hijacker) supported by w. The
+// returned wrapper shares state with base, so callers can read base.statusCode
+// after the handler has returned.
+func wrapResponseWriter(base *responseWriter) http.ResponseWriter {
+	_, isFlusher := base.ResponseWriter.(http.Flusher)
+	_, isHijacker := base.ResponseWriter.(http.Hijacker)
+	switch {
+	case isFlusher && isHijacker:
+		return rwFlushHijacker{responseWriter: base}
+	case isFlusher:
+		return rwFlusher{responseWriter: base}
+	case isHijacker:
+		return rwHijacker{responseWriter: base}
+	default:
+		return base
+	}
+}
+
 // AutoPromoteMiddleware returns middleware that captures the response status
 // code and evaluates the given PromotionPolicy values after the downstream
 // handler returns. If any policy matches, the request's buffer is promoted to
@@ -58,13 +125,13 @@ func (rw *responseWriter) Unwrap() http.ResponseWriter {
 func AutoPromoteMiddleware(store Storer, policies ...PromotionPolicy) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
-			next.ServeHTTP(rw, r)
+			base := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+			next.ServeHTTP(wrapResponseWriter(base), r)
 
 			// Check if any policy triggers promotion.
 			for _, p := range policies {
-				if p.Predicate(r, rw.statusCode) {
-					promoteFromRequest(store, r, rw.statusCode)
+				if p.Predicate(r, base.statusCode) {
+					promoteFromRequest(store, r, base.statusCode)
 					return
 				}
 			}

--- a/autopromote_test.go
+++ b/autopromote_test.go
@@ -247,6 +247,47 @@ func TestAutoPromote_ImplicitOKWhenNoWriteHeader(t *testing.T) {
 	assert.Empty(t, store.promoted())
 }
 
+func TestAutoPromote_PreservesParentRequestID(t *testing.T) {
+	store := &mockStorer{}
+	stack := newTestStack(store, []PromotionPolicy{StatusPolicy(500)}, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/items", http.NoBody)
+	// CorrelationMiddleware treats an incoming X-Request-ID as the parent ID
+	// when no explicit X-Parent-Request-ID header is set.
+	req.Header.Set("X-Request-ID", "parent-abc")
+	rec := httptest.NewRecorder()
+	stack.ServeHTTP(rec, req)
+
+	traces := store.promoted()
+	require.Len(t, traces, 1)
+	assert.Equal(t, "parent-abc", traces[0].ParentRequestID)
+	assert.NotEqual(t, "parent-abc", traces[0].RequestID,
+		"child request should have a distinct request ID")
+}
+
+func TestAutoPromote_PreservesBufferTags(t *testing.T) {
+	store := &mockStorer{}
+	stack := newTestStack(store, []PromotionPolicy{StatusPolicy(500)}, func(w http.ResponseWriter, r *http.Request) {
+		buf := GetBuffer(r.Context())
+		buf.Tag("user_id", "user-42")
+		buf.Tag("feature", "checkout")
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/orders", http.NoBody)
+	rec := httptest.NewRecorder()
+	stack.ServeHTTP(rec, req)
+
+	traces := store.promoted()
+	require.Len(t, traces, 1)
+	assert.Equal(t, map[string]string{
+		"user_id": "user-42",
+		"feature": "checkout",
+	}, traces[0].Tags)
+}
+
 func TestAutoPromote_WithoutCorrelationMiddleware_NoPromotion(t *testing.T) {
 	store := &mockStorer{}
 	// Use AutoPromoteMiddleware without CorrelationMiddleware.

--- a/bodycapture.go
+++ b/bodycapture.go
@@ -1,8 +1,10 @@
 package promolog
 
 import (
+	"bufio"
 	"bytes"
 	"io"
+	"net"
 	"net/http"
 )
 
@@ -90,7 +92,7 @@ func BodyCaptureMiddleware(opts ...BodyCaptureOption) func(http.Handler) http.Ha
 				promoBuf:       buf,
 				redactor:       cfg.redactor,
 			}
-			next.ServeHTTP(crw, r)
+			next.ServeHTTP(wrapCaptureResponseWriter(crw), r)
 		})
 	}
 }
@@ -98,13 +100,15 @@ func BodyCaptureMiddleware(opts ...BodyCaptureOption) func(http.Handler) http.Ha
 // captureResponseWriter wraps http.ResponseWriter and copies written bytes
 // into a local buffer up to maxSize. After each Write the current captured
 // content (with optional redaction) is pushed into the per-request Buffer so
-// that inner middleware can access it.
+// that inner middleware can access it. It is never handed to downstream
+// handlers directly — wrapCaptureResponseWriter picks a variant whose method
+// set matches the optional interfaces supported by the underlying writer.
 type captureResponseWriter struct {
 	http.ResponseWriter
 	maxSize  int
 	capBuf   *bytes.Buffer // local accumulator
 	captured int
-	promoBuf *Buffer                   // per-request Buffer
+	promoBuf *Buffer                  // per-request Buffer
 	redactor func(body []byte) []byte // optional redaction hook
 }
 
@@ -136,4 +140,67 @@ func (crw *captureResponseWriter) WriteHeader(code int) {
 // the chain to access the original writer (e.g. for http.Flusher).
 func (crw *captureResponseWriter) Unwrap() http.ResponseWriter {
 	return crw.ResponseWriter
+}
+
+// The crw* variants below preserve the exact optional-interface method set of
+// the wrapped writer, for the same reason documented on responseWriter's
+// variants in autopromote.go.
+
+// crwFlusher forwards http.Flusher.
+type crwFlusher struct {
+	*captureResponseWriter
+}
+
+func (r crwFlusher) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// crwHijacker forwards http.Hijacker. Note: once the connection is hijacked,
+// any bytes written directly to the raw net.Conn bypass this wrapper's Write
+// method, so they will NOT be captured into the per-request Buffer. That is
+// an inherent limitation of hijacking — the middleware has no visibility into
+// the hijacked stream.
+type crwHijacker struct {
+	*captureResponseWriter
+}
+
+func (r crwHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return r.ResponseWriter.(http.Hijacker).Hijack()
+}
+
+// crwFlushHijacker forwards both http.Flusher and http.Hijacker.
+type crwFlushHijacker struct {
+	*captureResponseWriter
+}
+
+func (r crwFlushHijacker) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack delegates to the underlying writer. See the note on crwHijacker
+// about captured-bytes visibility after hijacking.
+func (r crwFlushHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return r.ResponseWriter.(http.Hijacker).Hijack()
+}
+
+// wrapCaptureResponseWriter returns an http.ResponseWriter whose method set
+// matches the optional interfaces (http.Flusher, http.Hijacker) supported by
+// the underlying writer. The returned wrapper shares state with base.
+func wrapCaptureResponseWriter(base *captureResponseWriter) http.ResponseWriter {
+	_, isFlusher := base.ResponseWriter.(http.Flusher)
+	_, isHijacker := base.ResponseWriter.(http.Hijacker)
+	switch {
+	case isFlusher && isHijacker:
+		return crwFlushHijacker{captureResponseWriter: base}
+	case isFlusher:
+		return crwFlusher{captureResponseWriter: base}
+	case isHijacker:
+		return crwHijacker{captureResponseWriter: base}
+	default:
+		return base
+	}
 }

--- a/export/json/json.go
+++ b/export/json/json.go
@@ -55,32 +55,38 @@ func New(w io.Writer, opts ...Option) *Exporter {
 // dedicated struct lets us add json tags and support field filtering without
 // modifying the core Trace type.
 type traceView struct {
-	RequestID  string            `json:"request_id"`
-	ErrorChain string            `json:"error_chain,omitempty"`
-	StatusCode int               `json:"status_code"`
-	Route      string            `json:"route"`
-	Method     string            `json:"method"`
-	UserAgent  string            `json:"user_agent,omitempty"`
-	RemoteIP   string            `json:"remote_ip,omitempty"`
-	UserID     string            `json:"user_id,omitempty"`
-	Tags       map[string]string `json:"tags,omitempty"`
-	Entries    []promolog.Entry  `json:"entries,omitempty"`
-	CreatedAt  string            `json:"created_at"`
+	RequestID       string            `json:"request_id"`
+	ParentRequestID string            `json:"parent_request_id,omitempty"`
+	ErrorChain      string            `json:"error_chain,omitempty"`
+	StatusCode      int               `json:"status_code"`
+	Route           string            `json:"route"`
+	Method          string            `json:"method"`
+	UserAgent       string            `json:"user_agent,omitempty"`
+	RemoteIP        string            `json:"remote_ip,omitempty"`
+	UserID          string            `json:"user_id,omitempty"`
+	Tags            map[string]string `json:"tags,omitempty"`
+	Entries         []promolog.Entry  `json:"entries,omitempty"`
+	RequestBody     string            `json:"request_body,omitempty"`
+	ResponseBody    string            `json:"response_body,omitempty"`
+	CreatedAt       string            `json:"created_at"`
 }
 
 func toView(t promolog.Trace) traceView {
 	return traceView{
-		RequestID:  t.RequestID,
-		ErrorChain: t.ErrorChain,
-		StatusCode: t.StatusCode,
-		Route:      t.Route,
-		Method:     t.Method,
-		UserAgent:  t.UserAgent,
-		RemoteIP:   t.RemoteIP,
-		UserID:     t.UserID,
-		Tags:       t.Tags,
-		Entries:    t.Entries,
-		CreatedAt:  t.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		RequestID:       t.RequestID,
+		ParentRequestID: t.ParentRequestID,
+		ErrorChain:      t.ErrorChain,
+		StatusCode:      t.StatusCode,
+		Route:           t.Route,
+		Method:          t.Method,
+		UserAgent:       t.UserAgent,
+		RemoteIP:        t.RemoteIP,
+		UserID:          t.UserID,
+		Tags:            t.Tags,
+		Entries:         t.Entries,
+		RequestBody:     t.RequestBody,
+		ResponseBody:    t.ResponseBody,
+		CreatedAt:       t.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
 	}
 }
 

--- a/export/json/json_test.go
+++ b/export/json/json_test.go
@@ -16,19 +16,22 @@ import (
 
 func sampleTrace() promolog.Trace {
 	return promolog.Trace{
-		RequestID:  "req-001",
-		ErrorChain: "something broke",
-		StatusCode: 500,
-		Route:      "/api/items",
-		Method:     "GET",
-		UserAgent:  "test-agent",
-		RemoteIP:   "127.0.0.1",
-		UserID:     "user-42",
-		Tags:       map[string]string{"env": "test"},
+		RequestID:       "req-001",
+		ParentRequestID: "parent-xyz",
+		ErrorChain:      "something broke",
+		StatusCode:      500,
+		Route:           "/api/items",
+		Method:          "GET",
+		UserAgent:       "test-agent",
+		RemoteIP:        "127.0.0.1",
+		UserID:          "user-42",
+		Tags:            map[string]string{"env": "test"},
 		Entries: []promolog.Entry{
 			{Time: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Level: "ERROR", Message: "boom"},
 		},
-		CreatedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC),
+		RequestBody:  `{"q":"hello"}`,
+		ResponseBody: `{"error":"boom"}`,
+		CreatedAt:    time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC),
 	}
 }
 
@@ -83,6 +86,59 @@ func TestExport_WithFields(t *testing.T) {
 	assert.NotContains(t, m, "route")
 	assert.NotContains(t, m, "method")
 	assert.NotContains(t, m, "entries")
+	assert.NotContains(t, m, "request_body")
+	assert.NotContains(t, m, "response_body")
+	assert.NotContains(t, m, "parent_request_id")
+}
+
+func TestExport_IncludesParentRequestIDAndBodies(t *testing.T) {
+	var buf bytes.Buffer
+	exp := jsonexport.New(&buf)
+
+	err := exp.Export(context.Background(), sampleTrace())
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &m))
+
+	assert.Equal(t, "parent-xyz", m["parent_request_id"])
+	assert.Equal(t, `{"q":"hello"}`, m["request_body"])
+	assert.Equal(t, `{"error":"boom"}`, m["response_body"])
+}
+
+func TestExport_OmitsEmptyParentRequestIDAndBodies(t *testing.T) {
+	var buf bytes.Buffer
+	exp := jsonexport.New(&buf)
+
+	tr := sampleTrace()
+	tr.ParentRequestID = ""
+	tr.RequestBody = ""
+	tr.ResponseBody = ""
+	require.NoError(t, exp.Export(context.Background(), tr))
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &m))
+
+	assert.NotContains(t, m, "parent_request_id")
+	assert.NotContains(t, m, "request_body")
+	assert.NotContains(t, m, "response_body")
+}
+
+func TestExport_WithFields_FiltersByParentRequestID(t *testing.T) {
+	var buf bytes.Buffer
+	exp := jsonexport.New(&buf, jsonexport.WithFields("request_id", "parent_request_id"))
+
+	err := exp.Export(context.Background(), sampleTrace())
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &m))
+
+	assert.Equal(t, "req-001", m["request_id"])
+	assert.Equal(t, "parent-xyz", m["parent_request_id"])
+	assert.NotContains(t, m, "request_body")
+	assert.NotContains(t, m, "response_body")
+	assert.NotContains(t, m, "status_code")
 }
 
 func TestExport_MultipleTraces(t *testing.T) {

--- a/export/webhook/webhook.go
+++ b/export/webhook/webhook.go
@@ -66,32 +66,38 @@ func New(url string, opts ...Option) *Exporter {
 // tracePayload mirrors the JSON structure used by the JSON exporter for
 // consistency.
 type tracePayload struct {
-	RequestID  string            `json:"request_id"`
-	ErrorChain string            `json:"error_chain,omitempty"`
-	StatusCode int               `json:"status_code"`
-	Route      string            `json:"route"`
-	Method     string            `json:"method"`
-	UserAgent  string            `json:"user_agent,omitempty"`
-	RemoteIP   string            `json:"remote_ip,omitempty"`
-	UserID     string            `json:"user_id,omitempty"`
-	Tags       map[string]string `json:"tags,omitempty"`
-	Entries    []promolog.Entry  `json:"entries,omitempty"`
-	CreatedAt  string            `json:"created_at"`
+	RequestID       string            `json:"request_id"`
+	ParentRequestID string            `json:"parent_request_id,omitempty"`
+	ErrorChain      string            `json:"error_chain,omitempty"`
+	StatusCode      int               `json:"status_code"`
+	Route           string            `json:"route"`
+	Method          string            `json:"method"`
+	UserAgent       string            `json:"user_agent,omitempty"`
+	RemoteIP        string            `json:"remote_ip,omitempty"`
+	UserID          string            `json:"user_id,omitempty"`
+	Tags            map[string]string `json:"tags,omitempty"`
+	Entries         []promolog.Entry  `json:"entries,omitempty"`
+	RequestBody     string            `json:"request_body,omitempty"`
+	ResponseBody    string            `json:"response_body,omitempty"`
+	CreatedAt       string            `json:"created_at"`
 }
 
 func toPayload(t promolog.Trace) tracePayload {
 	return tracePayload{
-		RequestID:  t.RequestID,
-		ErrorChain: t.ErrorChain,
-		StatusCode: t.StatusCode,
-		Route:      t.Route,
-		Method:     t.Method,
-		UserAgent:  t.UserAgent,
-		RemoteIP:   t.RemoteIP,
-		UserID:     t.UserID,
-		Tags:       t.Tags,
-		Entries:    t.Entries,
-		CreatedAt:  t.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		RequestID:       t.RequestID,
+		ParentRequestID: t.ParentRequestID,
+		ErrorChain:      t.ErrorChain,
+		StatusCode:      t.StatusCode,
+		Route:           t.Route,
+		Method:          t.Method,
+		UserAgent:       t.UserAgent,
+		RemoteIP:        t.RemoteIP,
+		UserID:          t.UserID,
+		Tags:            t.Tags,
+		Entries:         t.Entries,
+		RequestBody:     t.RequestBody,
+		ResponseBody:    t.ResponseBody,
+		CreatedAt:       t.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
 	}
 }
 

--- a/export/webhook/webhook_test.go
+++ b/export/webhook/webhook_test.go
@@ -18,19 +18,22 @@ import (
 
 func sampleTrace() promolog.Trace {
 	return promolog.Trace{
-		RequestID:  "req-001",
-		ErrorChain: "something broke",
-		StatusCode: 500,
-		Route:      "/api/items",
-		Method:     "GET",
-		UserAgent:  "test-agent",
-		RemoteIP:   "127.0.0.1",
-		UserID:     "user-42",
-		Tags:       map[string]string{"env": "test"},
+		RequestID:       "req-001",
+		ParentRequestID: "parent-xyz",
+		ErrorChain:      "something broke",
+		StatusCode:      500,
+		Route:           "/api/items",
+		Method:          "GET",
+		UserAgent:       "test-agent",
+		RemoteIP:        "127.0.0.1",
+		UserID:          "user-42",
+		Tags:            map[string]string{"env": "test"},
 		Entries: []promolog.Entry{
 			{Time: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Level: "ERROR", Message: "boom"},
 		},
-		CreatedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC),
+		RequestBody:  `{"q":"hello"}`,
+		ResponseBody: `{"error":"boom"}`,
+		CreatedAt:    time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC),
 	}
 }
 
@@ -101,6 +104,46 @@ func TestExport_ConnectionRefused(t *testing.T) {
 func TestClose(t *testing.T) {
 	exp := webhook.New("http://example.com")
 	assert.NoError(t, exp.Close())
+}
+
+func TestExport_IncludesParentRequestIDAndBodies(t *testing.T) {
+	var received map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &received)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	exp := webhook.New(srv.URL)
+	err := exp.Export(context.Background(), sampleTrace())
+	require.NoError(t, err)
+
+	assert.Equal(t, "parent-xyz", received["parent_request_id"])
+	assert.Equal(t, `{"q":"hello"}`, received["request_body"])
+	assert.Equal(t, `{"error":"boom"}`, received["response_body"])
+}
+
+func TestExport_OmitsEmptyParentRequestIDAndBodies(t *testing.T) {
+	var received map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &received)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tr := sampleTrace()
+	tr.ParentRequestID = ""
+	tr.RequestBody = ""
+	tr.ResponseBody = ""
+
+	exp := webhook.New(srv.URL)
+	require.NoError(t, exp.Export(context.Background(), tr))
+
+	assert.NotContains(t, received, "parent_request_id")
+	assert.NotContains(t, received, "request_body")
+	assert.NotContains(t, received, "response_body")
 }
 
 func TestWithClient(t *testing.T) {

--- a/policy.go
+++ b/policy.go
@@ -2,6 +2,7 @@ package promolog
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"net/http"
 	"path"
@@ -48,10 +49,15 @@ func RoutePolicy(pattern string, predicate func(statusCode int) bool) PromotionP
 }
 
 // SamplePolicy returns a PromotionPolicy that promotes a random fraction of
-// requests. rate must be between 0 and 1 (e.g. 0.01 = 1%). An optional
-// *rand.Rand source can be provided for deterministic testing; when nil a
-// default source is used.
+// requests. rate must be in the closed interval [0, 1] (e.g. 0.01 = 1%).
+// Values outside that range, or NaN, panic at construction time because they
+// indicate a configuration bug that should fail loudly rather than silently
+// misbehave. An optional *rand.Rand source can be provided for deterministic
+// testing; when nil a default source is used.
 func SamplePolicy(rate float64, rng *rand.Rand) PromotionPolicy {
+	if math.IsNaN(rate) || rate < 0 || rate > 1 {
+		panic(fmt.Sprintf("promolog: SamplePolicy rate must be in [0, 1], got %v", rate))
+	}
 	if rng == nil {
 		rng = rand.New(rand.NewSource(time.Now().UnixNano()))
 	}

--- a/policy_test.go
+++ b/policy_test.go
@@ -2,6 +2,7 @@ package promolog
 
 import (
 	"context"
+	"math"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -144,6 +145,29 @@ func TestSamplePolicy_Deterministic(t *testing.T) {
 func TestSamplePolicy_Name(t *testing.T) {
 	p := SamplePolicy(0.01, nil)
 	assert.Equal(t, "sample:0.0100", p.Name)
+}
+
+func TestSamplePolicy_PanicsOnNegativeRate(t *testing.T) {
+	assert.PanicsWithValue(t,
+		"promolog: SamplePolicy rate must be in [0, 1], got -0.1",
+		func() { _ = SamplePolicy(-0.1, nil) },
+	)
+}
+
+func TestSamplePolicy_PanicsOnRateAboveOne(t *testing.T) {
+	assert.PanicsWithValue(t,
+		"promolog: SamplePolicy rate must be in [0, 1], got 1.5",
+		func() { _ = SamplePolicy(1.5, nil) },
+	)
+}
+
+func TestSamplePolicy_PanicsOnNaN(t *testing.T) {
+	assert.Panics(t, func() { _ = SamplePolicy(math.NaN(), nil) })
+}
+
+func TestSamplePolicy_BoundaryRatesDoNotPanic(t *testing.T) {
+	assert.NotPanics(t, func() { _ = SamplePolicy(0, nil) })
+	assert.NotPanics(t, func() { _ = SamplePolicy(1, nil) })
 }
 
 // --- LatencyPolicy ---

--- a/responsewriter_interfaces_test.go
+++ b/responsewriter_interfaces_test.go
@@ -1,0 +1,249 @@
+package promolog
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- stub ResponseWriter implementations for interface testing ---
+
+// plainWriter implements only http.ResponseWriter.
+type plainWriter struct {
+	header http.Header
+	body   bytes.Buffer
+	status int
+}
+
+func newPlainWriter() *plainWriter {
+	return &plainWriter{header: make(http.Header)}
+}
+
+func (p *plainWriter) Header() http.Header         { return p.header }
+func (p *plainWriter) Write(b []byte) (int, error) { return p.body.Write(b) }
+func (p *plainWriter) WriteHeader(code int)        { p.status = code }
+
+// flusherWriter implements http.ResponseWriter and http.Flusher.
+type flusherWriter struct {
+	plainWriter
+	flushed int
+}
+
+func newFlusherWriter() *flusherWriter {
+	return &flusherWriter{plainWriter: plainWriter{header: make(http.Header)}}
+}
+
+func (f *flusherWriter) Flush() { f.flushed++ }
+
+// hijackerWriter implements http.ResponseWriter and http.Hijacker.
+type hijackerWriter struct {
+	plainWriter
+	hijacked bool
+	hijErr   error
+}
+
+func newHijackerWriter() *hijackerWriter {
+	return &hijackerWriter{plainWriter: plainWriter{header: make(http.Header)}}
+}
+
+func (h *hijackerWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h.hijacked = true
+	if h.hijErr != nil {
+		return nil, nil, h.hijErr
+	}
+	// Return a sentinel non-nil value so callers can detect delegation.
+	return nil, &bufio.ReadWriter{}, nil
+}
+
+// flusherHijackerWriter implements http.ResponseWriter, http.Flusher, and
+// http.Hijacker.
+type flusherHijackerWriter struct {
+	plainWriter
+	flushed  int
+	hijacked bool
+}
+
+func newFlusherHijackerWriter() *flusherHijackerWriter {
+	return &flusherHijackerWriter{plainWriter: plainWriter{header: make(http.Header)}}
+}
+
+func (f *flusherHijackerWriter) Flush() { f.flushed++ }
+
+func (f *flusherHijackerWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	f.hijacked = true
+	return nil, &bufio.ReadWriter{}, nil
+}
+
+// --- responseWriter (autopromote) interface preservation tests ---
+
+func TestAutoPromoteWrapper_PlainWriter_NoOptionalInterfaces(t *testing.T) {
+	base := &responseWriter{ResponseWriter: newPlainWriter(), statusCode: http.StatusOK}
+	w := wrapResponseWriter(base)
+	_, isFlusher := w.(http.Flusher)
+	_, isHijacker := w.(http.Hijacker)
+	assert.False(t, isFlusher, "plain writer must not expose http.Flusher")
+	assert.False(t, isHijacker, "plain writer must not expose http.Hijacker")
+}
+
+func TestAutoPromoteWrapper_PreservesFlusher(t *testing.T) {
+	inner := newFlusherWriter()
+	base := &responseWriter{ResponseWriter: inner, statusCode: http.StatusOK}
+	w := wrapResponseWriter(base)
+
+	f, ok := w.(http.Flusher)
+	require.True(t, ok, "wrapper must implement http.Flusher when underlying writer does")
+	f.Flush()
+	assert.Equal(t, 1, inner.flushed, "Flush must delegate to underlying writer")
+
+	_, isHijacker := w.(http.Hijacker)
+	assert.False(t, isHijacker, "must not expose http.Hijacker when underlying writer does not")
+}
+
+func TestAutoPromoteWrapper_PreservesHijacker(t *testing.T) {
+	inner := newHijackerWriter()
+	base := &responseWriter{ResponseWriter: inner, statusCode: http.StatusOK}
+	w := wrapResponseWriter(base)
+
+	h, ok := w.(http.Hijacker)
+	require.True(t, ok, "wrapper must implement http.Hijacker when underlying writer does")
+	_, _, err := h.Hijack()
+	require.NoError(t, err)
+	assert.True(t, inner.hijacked, "Hijack must delegate to underlying writer")
+
+	_, isFlusher := w.(http.Flusher)
+	assert.False(t, isFlusher, "must not expose http.Flusher when underlying writer does not")
+}
+
+func TestAutoPromoteWrapper_PreservesFlusherAndHijacker(t *testing.T) {
+	inner := newFlusherHijackerWriter()
+	base := &responseWriter{ResponseWriter: inner, statusCode: http.StatusOK}
+	w := wrapResponseWriter(base)
+
+	f, ok := w.(http.Flusher)
+	require.True(t, ok)
+	f.Flush()
+	assert.Equal(t, 1, inner.flushed)
+
+	h, ok := w.(http.Hijacker)
+	require.True(t, ok)
+	_, _, err := h.Hijack()
+	require.NoError(t, err)
+	assert.True(t, inner.hijacked)
+}
+
+func TestAutoPromoteWrapper_HijackErrorPropagates(t *testing.T) {
+	inner := newHijackerWriter()
+	inner.hijErr = errors.New("boom")
+	base := &responseWriter{ResponseWriter: inner, statusCode: http.StatusOK}
+	w := wrapResponseWriter(base)
+
+	h, ok := w.(http.Hijacker)
+	require.True(t, ok)
+	_, _, err := h.Hijack()
+	assert.EqualError(t, err, "boom")
+}
+
+func TestAutoPromoteWrapper_HandlerCanTypeAssertFlusher(t *testing.T) {
+	// End-to-end: run AutoPromoteMiddleware and verify the handler sees a
+	// working http.Flusher when the underlying writer supports it.
+	store := &mockStorer{}
+	var sawFlusher bool
+	stack := newTestStack(store, nil, func(w http.ResponseWriter, _ *http.Request) {
+		_, sawFlusher = w.(http.Flusher)
+		w.WriteHeader(http.StatusOK)
+	})
+	// httptest.ResponseRecorder does not implement http.Flusher, so wrap it
+	// into a stub that does.
+	inner := newFlusherWriter()
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	stack.ServeHTTP(inner, req)
+	assert.True(t, sawFlusher, "handler must observe a Flusher through the wrapper")
+}
+
+// --- captureResponseWriter (bodycapture) interface preservation tests ---
+
+func newCRW(inner http.ResponseWriter) *captureResponseWriter {
+	return &captureResponseWriter{
+		ResponseWriter: inner,
+		maxSize:        1024,
+		capBuf:         &bytes.Buffer{},
+		promoBuf:       &Buffer{},
+	}
+}
+
+func TestBodyCaptureWrapper_PlainWriter_NoOptionalInterfaces(t *testing.T) {
+	w := wrapCaptureResponseWriter(newCRW(newPlainWriter()))
+	_, isFlusher := w.(http.Flusher)
+	_, isHijacker := w.(http.Hijacker)
+	assert.False(t, isFlusher)
+	assert.False(t, isHijacker)
+}
+
+func TestBodyCaptureWrapper_PreservesFlusher(t *testing.T) {
+	inner := newFlusherWriter()
+	w := wrapCaptureResponseWriter(newCRW(inner))
+
+	f, ok := w.(http.Flusher)
+	require.True(t, ok, "wrapper must implement http.Flusher when underlying writer does")
+	f.Flush()
+	assert.Equal(t, 1, inner.flushed)
+
+	_, isHijacker := w.(http.Hijacker)
+	assert.False(t, isHijacker)
+}
+
+func TestBodyCaptureWrapper_PreservesHijacker(t *testing.T) {
+	inner := newHijackerWriter()
+	w := wrapCaptureResponseWriter(newCRW(inner))
+
+	h, ok := w.(http.Hijacker)
+	require.True(t, ok, "wrapper must implement http.Hijacker when underlying writer does")
+	_, _, err := h.Hijack()
+	require.NoError(t, err)
+	assert.True(t, inner.hijacked)
+
+	_, isFlusher := w.(http.Flusher)
+	assert.False(t, isFlusher)
+}
+
+func TestBodyCaptureWrapper_PreservesFlusherAndHijacker(t *testing.T) {
+	inner := newFlusherHijackerWriter()
+	w := wrapCaptureResponseWriter(newCRW(inner))
+
+	f, ok := w.(http.Flusher)
+	require.True(t, ok)
+	f.Flush()
+	assert.Equal(t, 1, inner.flushed)
+
+	h, ok := w.(http.Hijacker)
+	require.True(t, ok)
+	_, _, err := h.Hijack()
+	require.NoError(t, err)
+	assert.True(t, inner.hijacked)
+}
+
+func TestBodyCaptureWrapper_HandlerCanTypeAssertHijacker(t *testing.T) {
+	// End-to-end: run BodyCaptureMiddleware with CorrelationMiddleware and
+	// verify the handler sees an http.Hijacker when the underlying writer
+	// supports it.
+	var sawHijacker bool
+	stack := CorrelationMiddleware(
+		BodyCaptureMiddleware()(
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, sawHijacker = w.(http.Hijacker)
+				w.WriteHeader(http.StatusOK)
+			}),
+		),
+	)
+	inner := newHijackerWriter()
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	stack.ServeHTTP(inner, req)
+	assert.True(t, sawHijacker, "handler must observe a Hijacker through the wrapper")
+}


### PR DESCRIPTION
## Summary

- Auto-promoted traces now carry `ParentRequestID` and `Tags` so distributed linkage and per-request tags survive AutoPromoteMiddleware (#49).
- `SamplePolicy` panics with a clear message on rate values outside `[0, 1]` or `NaN`; `0` and `1` remain valid (#50).
- JSON and webhook exporters now emit `parent_request_id`, `request_body`, and `response_body` with `omitempty`, keeping exporter output consistent with the documented `Trace` model (#51).
- Middleware `ResponseWriter` wrappers now preserve `http.Flusher` and `http.Hijacker` exactly — implemented via four dynamic wrapper variants per middleware so optional interfaces are only exposed when the underlying writer supports them, avoiding false-positive type assertions (#52).

## Test plan

- [x] `go test ./...` passes (151 tests, 0 skipped)
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] New tests cover: parent ID + tag propagation through AutoPromoteMiddleware
- [x] New tests cover: `SamplePolicy` invalid (`<0`, `>1`, `NaN`) panics; boundary (`0`, `1`) does not
- [x] New tests cover: JSON + webhook exporters emit and omit the three new fields; `WithFields` filters on `parent_request_id`
- [x] New tests cover: wrapper preserves `http.Flusher` / `http.Hijacker` across all four combinations using stub writers (not `httptest.ResponseRecorder`, which lacks Hijacker)
- [ ] Manual sanity check in a downstream service

Fixes #49
Fixes #50
Fixes #51
Fixes #52