### PR TITLE
fix: remove duplicate replace directive in sqlite/go.mod

### DIFF
--- a/sqlite/go.mod
+++ b/sqlite/go.mod
@@ -1,8 +1,6 @@
 module github.com/catgoose/promolog/sqlite
 
-go 1.26.1
-
-replace github.com/catgoose/promolog => ../
+go 1.26.2
 
 require (
 	github.com/catgoose/promolog v0.2.8


### PR DESCRIPTION
## Summary
- `sqlite/go.mod` declared `replace github.com/catgoose/promolog => ../` twice. Newer Go toolchain versions reject this on fresh module resolution with `go: updates to go.mod needed`, which is what broke Pipeline on main after #53 merged on a cold CI module cache (reopening #7).
- `go mod tidy` in `sqlite/` drops the duplicate and — because 85e1790 bumped the parent to `go 1.26.2` — auto-bumps sqlite's go directive to 1.26.2 to satisfy the transitive requirement through the replace. Both changes are needed; leaving sqlite at 1.26.1 would fail tidy with `module ../ requires go >= 1.26.2`.

This is a pre-existing latent bug (the duplicate has been present since well before #53) that #53's merge surfaced by cold-starting CI. The fix is one commit, one file.

## Test plan
- [x] `cd sqlite && go mod tidy` is a no-op after the change
- [x] `cd sqlite && go vet ./...` — clean (this is the exact command that failed on main)
- [x] `cd sqlite && go test -race -v ./...` — all passing
- [x] `make ci` from repo root — all four packages green, zero failures

Closes #7.