### PR TITLE
sqlite: add EnsureSchema alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ import (
 // 1. Set up the store
 db, _ := sql.Open("sqlite3", "traces.db")
 store := sqlite.NewStore(db)
-store.InitSchema()
+store.EnsureSchema()
 store.StartCleanup(ctx, 90*24*time.Hour, time.Hour)
 
 // 2. Wrap your slog handler
@@ -590,6 +590,10 @@ type Storer interface {
     Aggregate(ctx context.Context, f AggregateFilter) ([]AggregateResult, error)
 }
 ```
+
+The SQLite store also provides `EnsureSchema()` as the preferred idempotent
+startup/migration entry point. `InitSchema()` remains available as a
+compatibility alias.
 
 ## Duplicate handling
 

--- a/autopromote_test.go
+++ b/autopromote_test.go
@@ -18,7 +18,8 @@ type mockStorer struct {
 	traces []Trace
 }
 
-func (m *mockStorer) InitSchema() error                         { return nil }
+func (m *mockStorer) EnsureSchema() error                       { return nil }
+func (m *mockStorer) InitSchema() error                         { return m.EnsureSchema() }
 func (m *mockStorer) SetOnPromote(_ func(TraceSummary))         {}
 func (m *mockStorer) Get(_ context.Context, _ string) (*Trace, error) {
 	return nil, nil

--- a/sqlite/example_test.go
+++ b/sqlite/example_test.go
@@ -21,7 +21,7 @@ func ExampleNewStore() {
 	db.SetMaxOpenConns(1)
 
 	store := sqlite.NewStore(db)
-	if err := store.InitSchema(); err != nil {
+	if err := store.EnsureSchema(); err != nil {
 		panic(err)
 	}
 
@@ -34,7 +34,7 @@ func ExampleStore_Promote() {
 	defer db.Close()
 	db.SetMaxOpenConns(1)
 	store := sqlite.NewStore(db)
-	_ = store.InitSchema()
+	_ = store.EnsureSchema()
 
 	ctx := context.Background()
 
@@ -74,7 +74,7 @@ func ExampleStore_Get() {
 	defer db.Close()
 	db.SetMaxOpenConns(1)
 	store := sqlite.NewStore(db)
-	_ = store.InitSchema()
+	_ = store.EnsureSchema()
 
 	ctx := context.Background()
 	_ = store.Promote(ctx, promolog.Trace{
@@ -110,7 +110,7 @@ func ExampleStore_ListTraces() {
 	defer db.Close()
 	db.SetMaxOpenConns(1)
 	store := sqlite.NewStore(db)
-	_ = store.InitSchema()
+	_ = store.EnsureSchema()
 
 	ctx := context.Background()
 	_ = store.Promote(ctx, promolog.Trace{
@@ -153,7 +153,7 @@ func ExampleStore_AvailableFilters() {
 	defer db.Close()
 	db.SetMaxOpenConns(1)
 	store := sqlite.NewStore(db)
-	_ = store.InitSchema()
+	_ = store.EnsureSchema()
 
 	ctx := context.Background()
 	_ = store.Promote(ctx, promolog.Trace{
@@ -182,7 +182,7 @@ func ExampleStore_SetOnPromote() {
 	defer db.Close()
 	db.SetMaxOpenConns(1)
 	store := sqlite.NewStore(db)
-	_ = store.InitSchema()
+	_ = store.EnsureSchema()
 
 	// Register a callback for real-time notifications (SSE, webhooks, etc.).
 	store.SetOnPromote(func(ts promolog.TraceSummary) {
@@ -205,7 +205,7 @@ func ExampleStore_DeleteTrace() {
 	defer db.Close()
 	db.SetMaxOpenConns(1)
 	store := sqlite.NewStore(db)
-	_ = store.InitSchema()
+	_ = store.EnsureSchema()
 
 	ctx := context.Background()
 	_ = store.Promote(ctx, promolog.Trace{

--- a/sqlite/go.mod
+++ b/sqlite/go.mod
@@ -1,6 +1,6 @@
 module github.com/catgoose/promolog/sqlite
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/catgoose/promolog v0.2.8

--- a/sqlite/retention_test.go
+++ b/sqlite/retention_test.go
@@ -262,11 +262,11 @@ func TestStartCleanup_RetentionRuleShortestTTLWins(t *testing.T) {
 
 // --- Schema idempotency ---
 
-func TestInitSchema_RetentionRulesIdempotent(t *testing.T) {
+func TestEnsureSchema_RetentionRulesIdempotent(t *testing.T) {
 	db := openTestDB(t)
 	store := NewStore(db)
-	require.NoError(t, store.InitSchema())
-	require.NoError(t, store.InitSchema())
+	require.NoError(t, store.EnsureSchema())
+	require.NoError(t, store.EnsureSchema())
 
 	_, err := store.CreateRetentionRule(context.Background(), sampleRetentionRule())
 	require.NoError(t, err)

--- a/sqlite/rule_test.go
+++ b/sqlite/rule_test.go
@@ -150,13 +150,13 @@ func TestLoadRuleEngine_NoRules(t *testing.T) {
 	assert.False(t, matched)
 }
 
-func TestInitSchema_FilterRulesIdempotent(t *testing.T) {
+func TestEnsureSchema_FilterRulesIdempotent(t *testing.T) {
 	db := openTestDB(t)
 	store := NewStore(db)
-	require.NoError(t, store.InitSchema())
-	require.NoError(t, store.InitSchema())
+	require.NoError(t, store.EnsureSchema())
+	require.NoError(t, store.EnsureSchema())
 
-	// Verify we can use filter_rules after double init.
+	// Verify we can use filter_rules after double ensure.
 	_, err := store.CreateRule(context.Background(), sampleRule())
 	require.NoError(t, err)
 }

--- a/sqlite/store.go
+++ b/sqlite/store.go
@@ -73,9 +73,10 @@ func NewStore(db *sql.DB) *Store {
 	return &Store{db: db}
 }
 
-// InitSchema creates the error_traces table if it doesn't exist.
-// It also applies any necessary migrations for existing databases.
-func (s *Store) InitSchema() error {
+// EnsureSchema creates the error_traces table if it doesn't exist and applies
+// any additive migrations to bring an existing database up to date. It is safe
+// to call on every startup.
+func (s *Store) EnsureSchema() error {
 	if _, err := s.db.Exec(schema); err != nil {
 		return err
 	}
@@ -116,6 +117,13 @@ func (s *Store) InitSchema() error {
 	}
 	return nil
 }
+
+// InitSchema is a deprecated alias for [Store.EnsureSchema]. New code should
+// call EnsureSchema directly; the name better reflects the idempotent
+// startup/migration behavior.
+//
+// Deprecated: use EnsureSchema.
+func (s *Store) InitSchema() error { return s.EnsureSchema() }
 
 // SetOnPromote registers a callback invoked after each successful promote.
 func (s *Store) SetOnPromote(fn func(promolog.TraceSummary)) {

--- a/sqlite/store_test.go
+++ b/sqlite/store_test.go
@@ -27,7 +27,7 @@ func newTestStore(t *testing.T) *Store {
 	t.Helper()
 	db := openTestDB(t)
 	store := NewStore(db)
-	require.NoError(t, store.InitSchema())
+	require.NoError(t, store.EnsureSchema())
 	return store
 }
 
@@ -383,12 +383,22 @@ func TestStartCleanup_StopsOnContextCancel(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 }
 
-// --- InitSchema idempotency ---
+// --- EnsureSchema idempotency ---
 
-func TestInitSchema_Idempotent(t *testing.T) {
+func TestEnsureSchema_Idempotent(t *testing.T) {
+	db := openTestDB(t)
+	store := NewStore(db)
+	require.NoError(t, store.EnsureSchema())
+	require.NoError(t, store.EnsureSchema())
+}
+
+// TestInitSchema_AliasDelegates verifies the deprecated InitSchema alias still
+// drives the same idempotent ensure/migrate path as EnsureSchema.
+func TestInitSchema_AliasDelegates(t *testing.T) {
 	db := openTestDB(t)
 	store := NewStore(db)
 	require.NoError(t, store.InitSchema())
+	require.NoError(t, store.EnsureSchema())
 	require.NoError(t, store.InitSchema())
 }
 


### PR DESCRIPTION
## Summary
- add `EnsureSchema()` to `sqlite.Store` for the existing idempotent startup/migration path
- keep `InitSchema()` as a deprecated compatibility alias and move docs/examples/tests to the clearer name
- normalize `sqlite/go.mod` to `go 1.26.3` so the nested module tests run cleanly with the current toolchain

## Testing
- `GOFLAGS=-mod=mod go test ./...`
- `cd sqlite && GOFLAGS=-mod=mod go test ./...`

Closes #55