### PR TITLE
sqlite: remove InitSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ any backend:
 
 ```go
 type Storer interface {
-    InitSchema() error
+    EnsureSchema() error
     SetOnPromote(fn func(TraceSummary))
     Promote(ctx context.Context, trace Trace) error
     PromoteAt(ctx context.Context, trace Trace, createdAt time.Time) error
@@ -590,10 +590,6 @@ type Storer interface {
     Aggregate(ctx context.Context, f AggregateFilter) ([]AggregateResult, error)
 }
 ```
-
-The SQLite store also provides `EnsureSchema()` as the preferred idempotent
-startup/migration entry point. `InitSchema()` remains available as a
-compatibility alias.
 
 ## Duplicate handling
 

--- a/autopromote_test.go
+++ b/autopromote_test.go
@@ -19,7 +19,6 @@ type mockStorer struct {
 }
 
 func (m *mockStorer) EnsureSchema() error                       { return nil }
-func (m *mockStorer) InitSchema() error                         { return m.EnsureSchema() }
 func (m *mockStorer) SetOnPromote(_ func(TraceSummary))         {}
 func (m *mockStorer) Get(_ context.Context, _ string) (*Trace, error) {
 	return nil, nil

--- a/promolog.go
+++ b/promolog.go
@@ -292,7 +292,7 @@ type AggregateResult struct {
 
 // Storer defines the interface for trace persistence. Useful for mocking in tests.
 type Storer interface {
-	InitSchema() error
+	EnsureSchema() error
 	SetOnPromote(fn func(TraceSummary))
 	Promote(ctx context.Context, trace Trace) error
 	PromoteAt(ctx context.Context, trace Trace, createdAt time.Time) error

--- a/sqlite/store.go
+++ b/sqlite/store.go
@@ -118,13 +118,6 @@ func (s *Store) EnsureSchema() error {
 	return nil
 }
 
-// InitSchema is a deprecated alias for [Store.EnsureSchema]. New code should
-// call EnsureSchema directly; the name better reflects the idempotent
-// startup/migration behavior.
-//
-// Deprecated: use EnsureSchema.
-func (s *Store) InitSchema() error { return s.EnsureSchema() }
-
 // SetOnPromote registers a callback invoked after each successful promote.
 func (s *Store) SetOnPromote(fn func(promolog.TraceSummary)) {
 	s.onPromote = fn

--- a/sqlite/store_test.go
+++ b/sqlite/store_test.go
@@ -392,16 +392,6 @@ func TestEnsureSchema_Idempotent(t *testing.T) {
 	require.NoError(t, store.EnsureSchema())
 }
 
-// TestInitSchema_AliasDelegates verifies the deprecated InitSchema alias still
-// drives the same idempotent ensure/migrate path as EnsureSchema.
-func TestInitSchema_AliasDelegates(t *testing.T) {
-	db := openTestDB(t)
-	store := NewStore(db)
-	require.NoError(t, store.InitSchema())
-	require.NoError(t, store.EnsureSchema())
-	require.NoError(t, store.InitSchema())
-}
-
 // --- Promote edge cases ---
 
 func TestPromote_EmptyEntries(t *testing.T) {


### PR DESCRIPTION
## Summary
- remove `InitSchema()` from `promolog.Storer`
- remove the deprecated `sqlite.Store.InitSchema()` alias
- keep docs and tests aligned on `EnsureSchema()` as the only schema entry point

## Breaking Change
This removes the old `InitSchema()` API. Callers and custom `Storer` implementations must use `EnsureSchema()` instead.

## Testing
- `go test ./...`
- `cd sqlite && go test ./...`

Follow-up to #55 and #56.