### PR TITLE
sqlite: add one-shot cleanup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,11 @@ import (
 db, _ := sql.Open("sqlite3", "traces.db")
 store := sqlite.NewStore(db)
 store.EnsureSchema()
+// Background cleanup: every hour, delete traces older than 90 days
+// (retention rules can shorten TTL per-trace).
 store.StartCleanup(ctx, 90*24*time.Hour, time.Hour)
+// One-shot variant — useful in cron jobs or ad-hoc admin paths:
+//   deleted, err := store.RunCleanup(ctx, 90*24*time.Hour)
 
 // 2. Wrap your slog handler
 logger := slog.New(promolog.NewHandler(slog.Default().Handler()))
@@ -578,6 +582,7 @@ type Storer interface {
     ListTraces(ctx context.Context, f TraceFilter) ([]TraceSummary, int, error)
     AvailableFilters(ctx context.Context, f TraceFilter) (FilterOptions, error)
     DeleteTrace(ctx context.Context, requestID string) error
+    RunCleanup(ctx context.Context, defaultTTL time.Duration) (int, error)
     StartCleanup(ctx context.Context, ttl time.Duration, interval time.Duration)
     CreateRule(ctx context.Context, rule FilterRule) (FilterRule, error)
     ListRules(ctx context.Context) ([]FilterRule, error)

--- a/autopromote_test.go
+++ b/autopromote_test.go
@@ -30,6 +30,9 @@ func (m *mockStorer) AvailableFilters(_ context.Context, _ TraceFilter) (FilterO
 	return FilterOptions{}, nil
 }
 func (m *mockStorer) DeleteTrace(_ context.Context, _ string) error { return nil }
+func (m *mockStorer) RunCleanup(_ context.Context, _ time.Duration) (int, error) {
+	return 0, nil
+}
 func (m *mockStorer) StartCleanup(_ context.Context, _, _ time.Duration) {
 }
 func (m *mockStorer) Promote(_ context.Context, trace Trace) error {

--- a/promolog.go
+++ b/promolog.go
@@ -300,6 +300,7 @@ type Storer interface {
 	ListTraces(ctx context.Context, f TraceFilter) ([]TraceSummary, int, error)
 	AvailableFilters(ctx context.Context, f TraceFilter) (FilterOptions, error)
 	DeleteTrace(ctx context.Context, requestID string) error
+	RunCleanup(ctx context.Context, defaultTTL time.Duration) (int, error)
 	StartCleanup(ctx context.Context, ttl time.Duration, interval time.Duration)
 	CreateRule(ctx context.Context, rule FilterRule) (FilterRule, error)
 	ListRules(ctx context.Context) ([]FilterRule, error)

--- a/rule.go
+++ b/rule.go
@@ -121,6 +121,22 @@ func (re *RetentionEngine) HasRules() bool {
 	return re != nil && len(re.rules) > 0
 }
 
+// MinTTL returns the smallest TTL across all enabled rules, or 0 when no
+// rules are loaded. Callers use this to bound the candidate set during
+// cleanup so traces younger than any possible effective TTL are skipped.
+func (re *RetentionEngine) MinTTL() time.Duration {
+	if re == nil || len(re.rules) == 0 {
+		return 0
+	}
+	minHours := re.rules[0].TTLHours
+	for _, r := range re.rules[1:] {
+		if r.TTLHours < minHours {
+			minHours = r.TTLHours
+		}
+	}
+	return time.Duration(minHours) * time.Hour
+}
+
 // Match evaluates all loaded retention rules against the provided field values.
 // It returns the matching rule with the shortest TTL (most aggressive retention).
 // If no rule matches, matched is false.

--- a/sqlite/retention_test.go
+++ b/sqlite/retention_test.go
@@ -260,6 +260,62 @@ func TestStartCleanup_RetentionRuleShortestTTLWins(t *testing.T) {
 	assert.Nil(t, got, "trace should be deleted using shortest matching TTL")
 }
 
+// --- RunCleanup with retention rules ---
+
+func TestRunCleanup_AppliesRetentionRules(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Rule: health checks expire after 1 hour; default TTL is 24h.
+	_, err := store.CreateRetentionRule(ctx, promolog.RetentionRule{
+		Name: "short health", Field: "route", Operator: "equals",
+		Value: "/health", TTLHours: 1, Enabled: true,
+	})
+	require.NoError(t, err)
+
+	healthOld := sampleTrace("req-health-old", 200, "GET")
+	healthOld.Route = "/health"
+	require.NoError(t, store.PromoteAt(ctx, healthOld, time.Now().Add(-2*time.Hour)))
+
+	apiOld := sampleTrace("req-api-old", 500, "GET")
+	apiOld.Route = "/api/users"
+	require.NoError(t, store.PromoteAt(ctx, apiOld, time.Now().Add(-2*time.Hour)))
+
+	healthFresh := sampleTrace("req-health-fresh", 200, "GET")
+	healthFresh.Route = "/health"
+	require.NoError(t, store.Promote(ctx, healthFresh))
+
+	deleted, err := store.RunCleanup(ctx, 24*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleted, "only the old health trace should be deleted")
+
+	got, err := store.Get(ctx, "req-health-old")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	got, err = store.Get(ctx, "req-api-old")
+	require.NoError(t, err)
+	assert.NotNil(t, got)
+
+	got, err = store.Get(ctx, "req-health-fresh")
+	require.NoError(t, err)
+	assert.NotNil(t, got)
+}
+
+// TestRunCleanup_RetentionLoadErrorPropagates verifies that a retention-engine
+// load failure surfaces to direct RunCleanup callers instead of silently
+// degrading to default-TTL deletion. Setup: create error_traces but skip
+// retention_rules so LoadRetentionEngine's underlying query fails.
+func TestRunCleanup_RetentionLoadErrorPropagates(t *testing.T) {
+	db := openTestDB(t)
+	_, err := db.Exec(schema)
+	require.NoError(t, err)
+
+	store := NewStore(db)
+	_, err = store.RunCleanup(context.Background(), time.Hour)
+	require.Error(t, err, "retention engine load failure must not be swallowed")
+}
+
 // --- Schema idempotency ---
 
 func TestEnsureSchema_RetentionRulesIdempotent(t *testing.T) {

--- a/sqlite/store.go
+++ b/sqlite/store.go
@@ -437,9 +437,11 @@ func (s *Store) DeleteTrace(ctx context.Context, requestID string) error {
 	return err
 }
 
-// StartCleanup runs a background goroutine that deletes entries older than ttl.
-// If retention rules are configured, traces matching a rule use that rule's TTL
-// instead of the default. The shortest matching TTL wins.
+// StartCleanup runs a background goroutine that performs a cleanup pass every
+// interval. The loop is best-effort: errors (including retention-engine load
+// failures) are discarded and the loop falls back to default-TTL cleanup so a
+// transient rules-table problem does not stall global TTL enforcement. For
+// one-shot cleanup with error reporting, call [Store.RunCleanup] directly.
 func (s *Store) StartCleanup(ctx context.Context, ttl, interval time.Duration) {
 	go func() {
 		ticker := time.NewTicker(interval)
@@ -449,37 +451,56 @@ func (s *Store) StartCleanup(ctx context.Context, ttl, interval time.Duration) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				s.runCleanup(ctx, ttl)
+				engine, err := s.LoadRetentionEngine(ctx)
+				if err != nil {
+					engine = nil
+				}
+				_, _ = s.runCleanupWithEngine(ctx, ttl, engine)
 			}
 		}
 	}()
 }
 
-// runCleanup performs a single cleanup pass. Traces matching retention rules
-// use the rule's TTL; all others use the default TTL.
-func (s *Store) runCleanup(ctx context.Context, defaultTTL time.Duration) {
+// RunCleanup performs a single cleanup pass and returns the number of traces
+// deleted. Traces matching an enabled retention rule use that rule's TTL (the
+// shortest matching rule wins); all other traces use defaultTTL.
+//
+// Errors loading the retention engine, scanning candidates, or executing
+// deletes are surfaced to the caller — the public API does not silently
+// degrade to default-TTL cleanup on retention failures. Callers that want
+// best-effort cleanup should use [Store.StartCleanup] or layer their own
+// fallback on top.
+func (s *Store) RunCleanup(ctx context.Context, defaultTTL time.Duration) (int, error) {
 	engine, err := s.LoadRetentionEngine(ctx)
-	if err != nil || engine == nil {
-		// Fall back to simple default-TTL cleanup.
-		cutoff := time.Now().Add(-defaultTTL)
-		_, _ = s.db.ExecContext(ctx, "DELETE FROM error_traces WHERE created_at < ?", cutoff)
-		return
+	if err != nil {
+		return 0, fmt.Errorf("load retention engine: %w", err)
+	}
+	return s.runCleanupWithEngine(ctx, defaultTTL, engine)
+}
+
+// runCleanupWithEngine performs the cleanup pass using the supplied engine,
+// which may be nil or rule-less; in that case it falls back to a single
+// default-TTL delete. Splitting this out lets [Store.StartCleanup] retain its
+// best-effort fallback semantics without weakening the public RunCleanup
+// contract.
+func (s *Store) runCleanupWithEngine(ctx context.Context, defaultTTL time.Duration, engine *promolog.RetentionEngine) (int, error) {
+	if engine == nil || !engine.HasRules() {
+		return s.deleteOlderThan(ctx, time.Now().Add(-defaultTTL))
 	}
 
-	// If no retention rules are enabled, use the fast path.
-	if !engine.HasRules() {
-		cutoff := time.Now().Add(-defaultTTL)
-		_, _ = s.db.ExecContext(ctx, "DELETE FROM error_traces WHERE created_at < ?", cutoff)
-		return
+	// Candidate prefilter: any deletable row must be older than the shortest
+	// possible effective TTL across {defaultTTL, enabled rule TTLs}.
+	minTTL := defaultTTL
+	if rt := engine.MinTTL(); rt > 0 && rt < minTTL {
+		minTTL = rt
 	}
+	candidateCutoff := time.Now().Add(-minTTL)
 
-	// Scan all traces that are older than the shortest possible TTL.
-	// We check each trace against retention rules individually.
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT request_id, status_code, route, method, user_agent, remote_ip, user_id, created_at
-		FROM error_traces`)
+		FROM error_traces WHERE created_at < ?`, candidateCutoff)
 	if err != nil {
-		return
+		return 0, fmt.Errorf("query cleanup candidates: %w", err)
 	}
 	defer rows.Close()
 
@@ -490,7 +511,7 @@ func (s *Store) runCleanup(ctx context.Context, defaultTTL time.Duration) {
 		var statusCode int
 		var createdAt time.Time
 		if err := rows.Scan(&reqID, &statusCode, &route, &method, &userAgent, &remoteIP, &userID, &createdAt); err != nil {
-			continue
+			return 0, fmt.Errorf("scan cleanup candidate: %w", err)
 		}
 
 		fields := map[string]string{
@@ -511,11 +532,30 @@ func (s *Store) runCleanup(ctx context.Context, defaultTTL time.Duration) {
 			toDelete = append(toDelete, reqID)
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate cleanup candidates: %w", err)
+	}
 	_ = rows.Close()
 
+	deleted := 0
 	for _, reqID := range toDelete {
-		_, _ = s.db.ExecContext(ctx, "DELETE FROM error_traces WHERE request_id = ?", reqID)
+		res, err := s.db.ExecContext(ctx, "DELETE FROM error_traces WHERE request_id = ?", reqID)
+		if err != nil {
+			return deleted, fmt.Errorf("delete trace %s: %w", reqID, err)
+		}
+		n, _ := res.RowsAffected()
+		deleted += int(n)
 	}
+	return deleted, nil
+}
+
+func (s *Store) deleteOlderThan(ctx context.Context, cutoff time.Time) (int, error) {
+	res, err := s.db.ExecContext(ctx, "DELETE FROM error_traces WHERE created_at < ?", cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("delete expired traces: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
 }
 
 // --- Filter rules CRUD ---

--- a/sqlite/store_test.go
+++ b/sqlite/store_test.go
@@ -350,6 +350,47 @@ func TestAvailableFilters_ExcludesOwnDimension(t *testing.T) {
 	assert.Equal(t, []string{"GET", "POST"}, opts.Methods)
 }
 
+// --- RunCleanup tests ---
+
+func TestRunCleanup_DeletesExpiredTraces(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	old := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, store.PromoteAt(ctx, sampleTrace("req-old", 500, "GET"), old))
+	require.NoError(t, store.Promote(ctx, sampleTrace("req-new", 500, "GET")))
+
+	deleted, err := store.RunCleanup(ctx, 24*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleted)
+
+	got, err := store.Get(ctx, "req-old")
+	require.NoError(t, err)
+	assert.Nil(t, got, "expired trace should be deleted")
+
+	got, err = store.Get(ctx, "req-new")
+	require.NoError(t, err)
+	assert.NotNil(t, got, "fresh trace should survive")
+}
+
+func TestRunCleanup_NoExpiredTraces_ReturnsZero(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, store.Promote(ctx, sampleTrace("req-fresh", 500, "GET")))
+
+	deleted, err := store.RunCleanup(ctx, 24*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, deleted)
+}
+
+func TestRunCleanup_EmptyStore_ReturnsZero(t *testing.T) {
+	store := newTestStore(t)
+
+	deleted, err := store.RunCleanup(context.Background(), time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, deleted)
+}
+
 // --- StartCleanup tests ---
 
 func TestStartCleanup_DeletesExpiredTraces(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `RunCleanup(ctx, defaultTTL) (int, error)` as the public one-pass cleanup API
- keep `StartCleanup` as the background scheduler, with best-effort fallback behavior separated from direct-call error reporting
- prefilter retention cleanup candidates via `RetentionEngine.MinTTL()` and cover the new sync cleanup paths in tests/docs

## API Notes
- `RunCleanup` now surfaces retention-engine load errors to direct callers
- `StartCleanup` remains best-effort and may fall back to default-TTL cleanup if rule loading fails
- `promolog.Storer` now includes `RunCleanup`, so downstream implementations need to add it

## Testing
- `GOFLAGS=-mod=mod go test ./...`
- `cd sqlite && GOFLAGS=-mod=mod go test ./...`