### PR TITLE
ci: update sqlite module dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,14 +40,21 @@ jobs:
 
       - name: Update dependencies
         run: |
+          go_version=$(go version | sed -n 's/.*go\([0-9.]*\).*/\1/p')
           go get -u ./...
           go mod tidy
-          go mod edit -go=$(go version | sed -n 's/.*go\([0-9.]*\).*/\1/p')
+          go mod edit -go="$go_version"
+          (
+            cd sqlite
+            go get -u ./...
+            go mod tidy
+            go mod edit -go="$go_version"
+          )
 
       - name: Check for changes
         id: check-changes
         run: |
-          git add go.mod go.sum
+          git add go.mod go.sum sqlite/go.mod sqlite/go.sum
           if git diff --staged --quiet; then
             echo "changed=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,11 +27,8 @@ jobs:
           version: latest
           args: --timeout=5m
 
-      - name: Vet
-        run: go vet ./...
-
       - name: Test
-        run: go test -race ./...
+        run: make ci
 
   notify-failure:
     if: ${{ failure() }}

--- a/sqlite/go.mod
+++ b/sqlite/go.mod
@@ -1,6 +1,6 @@
 module github.com/catgoose/promolog/sqlite
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/catgoose/promolog v0.2.8


### PR DESCRIPTION
## Summary
- update the scheduled dependency workflow to run `go get`, `go mod tidy`, and Go-version edits in both root and `sqlite` modules
- include `sqlite/go.mod` and `sqlite/go.sum` in the auto-update commit check
- make PR checks run `make ci`, matching the main pipeline and covering the nested SQLite module
- align `sqlite/go.mod` with root `go.mod` at Go 1.26.4

## Root Cause
The scheduled Pipeline updated only the root module to Go 1.26.4. The test job then ran `make ci`, which includes `cd sqlite && go vet ./...`; the nested module still declared Go 1.26.3, so vet failed with `go: module ../ requires go >= 1.26.4`.

## Testing
- `make ci`