### PR TITLE
feat: support promoted traces for detached async operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,38 @@ Manual and automatic promotion use the same `Trace` struct and `Storer`
 interface. Use `AutoPromoteMiddleware` for policy-driven promotion, manual
 `Promote` for framework-specific error handling, or both together.
 
+### Detached operations
+
+Some failures happen in background work that outlives the HTTP request that
+started it -- a sync job, a queue consumer, a fire-and-forget goroutine.
+`StartOperation` begins a trace with its own log buffer; detach request
+cancellation with `context.WithoutCancel`, log against the operation context,
+and call `PromoteOperation` when the work finishes:
+
+```go
+func syncHandler(store promolog.Storer) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        opCtx, _ := promolog.StartOperation(r.Context(), "sales-goals-sync",
+            promolog.Attr("trigger", "manual"))
+
+        // Detach request cancellation so the work survives the response.
+        bg := context.WithoutCancel(opCtx)
+        go func() {
+            slog.InfoContext(bg, "sync started")
+            promolog.PromoteOperation(bg, store, runSync(bg))
+        }()
+
+        w.WriteHeader(http.StatusAccepted)
+    }
+}
+```
+
+Operation traces share the `Trace` struct and `Storer` with request traces.
+They set `Kind` to `"operation"` and carry an `OperationID`, `OperationName`,
+`Status`, `Duration`, and an `OriginRequestID` linking back to the request that
+started them, so a UI can tell the two apart. A nil error promotes a successful
+operation; a non-nil error records the terminal error chain and a failed status.
+
 ## Middleware stack
 
 ### Correlation
@@ -648,7 +680,12 @@ by setting `startTimeKey` via `CorrelationMiddleware`.
 | `CorrelationTransport`          | `http.RoundTripper` that propagates request IDs on outbound calls                   |
 | `NewCorrelatedClient`           | Creates an `http.Client` with request ID propagation                                |
 | `WireExporter`                  | Connects an Exporter to a store's OnPromote callback                                |
+| `StartOperation(ctx, name, ...attr)` | Begins a detached operation trace correlated to the current request          |
+| `PromoteOperation(ctx, store, err)`  | Persists the context's operation trace, recording err as the terminal error  |
+| `Attr(key, value)`              | Builds an operation attribute for `StartOperation`                                  |
+| `Operation`                     | Handle to a detached operation (exposes `ID` and `Name`)                            |
 | `ErrDuplicateTrace`             | Sentinel error for duplicate request IDs                                            |
+| `ErrNoOperation`                | Sentinel error when `PromoteOperation` finds no operation in the context           |
 
 ### SQLite store (`github.com/catgoose/promolog/sqlite`)
 

--- a/export/json/json.go
+++ b/export/json/json.go
@@ -68,11 +68,18 @@ type traceView struct {
 	Entries         []promolog.Entry  `json:"entries,omitempty"`
 	RequestBody     string            `json:"request_body,omitempty"`
 	ResponseBody    string            `json:"response_body,omitempty"`
+	Kind            string            `json:"kind,omitempty"`
+	OperationID     string            `json:"operation_id,omitempty"`
+	OperationName   string            `json:"operation_name,omitempty"`
+	OriginRequestID string            `json:"origin_request_id,omitempty"`
+	Status          string            `json:"status,omitempty"`
+	StartedAt       string            `json:"started_at,omitempty"`
+	DurationMS      int64             `json:"duration_ms,omitempty"`
 	CreatedAt       string            `json:"created_at"`
 }
 
 func toView(t promolog.Trace) traceView {
-	return traceView{
+	v := traceView{
 		RequestID:       t.RequestID,
 		ParentRequestID: t.ParentRequestID,
 		ErrorChain:      t.ErrorChain,
@@ -86,8 +93,18 @@ func toView(t promolog.Trace) traceView {
 		Entries:         t.Entries,
 		RequestBody:     t.RequestBody,
 		ResponseBody:    t.ResponseBody,
+		Kind:            t.Kind,
+		OperationID:     t.OperationID,
+		OperationName:   t.OperationName,
+		OriginRequestID: t.OriginRequestID,
+		Status:          t.Status,
+		DurationMS:      t.Duration.Milliseconds(),
 		CreatedAt:       t.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
 	}
+	if !t.StartedAt.IsZero() {
+		v.StartedAt = t.StartedAt.Format("2006-01-02T15:04:05Z07:00")
+	}
+	return v
 }
 
 // Export marshals the trace as JSON and writes it as a single line to the

--- a/export/json/json_test.go
+++ b/export/json/json_test.go
@@ -152,6 +152,53 @@ func TestExport_MultipleTraces(t *testing.T) {
 	assert.Len(t, lines, 2, "should have two JSON lines")
 }
 
+func TestExport_IncludesOperationFields(t *testing.T) {
+	var buf bytes.Buffer
+	exp := jsonexport.New(&buf)
+
+	started := time.Date(2025, 1, 1, 11, 0, 0, 0, time.UTC)
+	tr := promolog.Trace{
+		Kind:            promolog.TraceKindOperation,
+		RequestID:       "op-1",
+		OperationID:     "op-1",
+		OperationName:   "sales-goals-sync",
+		OriginRequestID: "req-origin",
+		Status:          promolog.OperationStatusFailed,
+		ErrorChain:      "upstream timeout",
+		StartedAt:       started,
+		Duration:        2 * time.Second,
+		CreatedAt:       time.Date(2025, 1, 1, 11, 0, 2, 0, time.UTC),
+	}
+	require.NoError(t, exp.Export(context.Background(), tr))
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &m))
+	assert.Equal(t, "operation", m["kind"])
+	assert.Equal(t, "op-1", m["operation_id"])
+	assert.Equal(t, "sales-goals-sync", m["operation_name"])
+	assert.Equal(t, "req-origin", m["origin_request_id"])
+	assert.Equal(t, "failed", m["status"])
+	assert.Equal(t, float64(2000), m["duration_ms"])
+	assert.Equal(t, "2025-01-01T11:00:00Z", m["started_at"])
+}
+
+func TestExport_OmitsOperationFieldsForRequestTrace(t *testing.T) {
+	var buf bytes.Buffer
+	exp := jsonexport.New(&buf)
+
+	require.NoError(t, exp.Export(context.Background(), sampleTrace()))
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &m))
+	assert.NotContains(t, m, "kind")
+	assert.NotContains(t, m, "operation_id")
+	assert.NotContains(t, m, "operation_name")
+	assert.NotContains(t, m, "origin_request_id")
+	assert.NotContains(t, m, "status")
+	assert.NotContains(t, m, "started_at")
+	assert.NotContains(t, m, "duration_ms")
+}
+
 func TestClose(t *testing.T) {
 	var buf bytes.Buffer
 	exp := jsonexport.New(&buf)

--- a/export/webhook/webhook.go
+++ b/export/webhook/webhook.go
@@ -79,11 +79,18 @@ type tracePayload struct {
 	Entries         []promolog.Entry  `json:"entries,omitempty"`
 	RequestBody     string            `json:"request_body,omitempty"`
 	ResponseBody    string            `json:"response_body,omitempty"`
+	Kind            string            `json:"kind,omitempty"`
+	OperationID     string            `json:"operation_id,omitempty"`
+	OperationName   string            `json:"operation_name,omitempty"`
+	OriginRequestID string            `json:"origin_request_id,omitempty"`
+	Status          string            `json:"status,omitempty"`
+	StartedAt       string            `json:"started_at,omitempty"`
+	DurationMS      int64             `json:"duration_ms,omitempty"`
 	CreatedAt       string            `json:"created_at"`
 }
 
 func toPayload(t promolog.Trace) tracePayload {
-	return tracePayload{
+	p := tracePayload{
 		RequestID:       t.RequestID,
 		ParentRequestID: t.ParentRequestID,
 		ErrorChain:      t.ErrorChain,
@@ -97,8 +104,18 @@ func toPayload(t promolog.Trace) tracePayload {
 		Entries:         t.Entries,
 		RequestBody:     t.RequestBody,
 		ResponseBody:    t.ResponseBody,
+		Kind:            t.Kind,
+		OperationID:     t.OperationID,
+		OperationName:   t.OperationName,
+		OriginRequestID: t.OriginRequestID,
+		Status:          t.Status,
+		DurationMS:      t.Duration.Milliseconds(),
 		CreatedAt:       t.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
 	}
+	if !t.StartedAt.IsZero() {
+		p.StartedAt = t.StartedAt.Format("2006-01-02T15:04:05Z07:00")
+	}
+	return p
 }
 
 // Export sends the trace as a JSON POST request to the configured URL. The

--- a/export/webhook/webhook_test.go
+++ b/export/webhook/webhook_test.go
@@ -146,6 +146,60 @@ func TestExport_OmitsEmptyParentRequestIDAndBodies(t *testing.T) {
 	assert.NotContains(t, received, "response_body")
 }
 
+func TestExport_IncludesOperationFields(t *testing.T) {
+	var received map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &received)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tr := promolog.Trace{
+		Kind:            promolog.TraceKindOperation,
+		RequestID:       "op-1",
+		OperationID:     "op-1",
+		OperationName:   "sales-goals-sync",
+		OriginRequestID: "req-origin",
+		Status:          promolog.OperationStatusFailed,
+		ErrorChain:      "upstream timeout",
+		StartedAt:       time.Date(2025, 1, 1, 11, 0, 0, 0, time.UTC),
+		Duration:        2 * time.Second,
+		CreatedAt:       time.Date(2025, 1, 1, 11, 0, 2, 0, time.UTC),
+	}
+	exp := webhook.New(srv.URL)
+	require.NoError(t, exp.Export(context.Background(), tr))
+
+	assert.Equal(t, "operation", received["kind"])
+	assert.Equal(t, "op-1", received["operation_id"])
+	assert.Equal(t, "sales-goals-sync", received["operation_name"])
+	assert.Equal(t, "req-origin", received["origin_request_id"])
+	assert.Equal(t, "failed", received["status"])
+	assert.Equal(t, float64(2000), received["duration_ms"])
+	assert.Equal(t, "2025-01-01T11:00:00Z", received["started_at"])
+}
+
+func TestExport_OmitsOperationFieldsForRequestTrace(t *testing.T) {
+	var received map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &received)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	exp := webhook.New(srv.URL)
+	require.NoError(t, exp.Export(context.Background(), sampleTrace()))
+
+	assert.NotContains(t, received, "kind")
+	assert.NotContains(t, received, "operation_id")
+	assert.NotContains(t, received, "operation_name")
+	assert.NotContains(t, received, "origin_request_id")
+	assert.NotContains(t, received, "status")
+	assert.NotContains(t, received, "started_at")
+	assert.NotContains(t, received, "duration_ms")
+}
+
 func TestWithClient(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/handler.go
+++ b/handler.go
@@ -56,7 +56,7 @@ func (h *Handler) Handle(ctx context.Context, r slog.Record) error {
 		}
 	}
 
-	if reqID != "" {
+	if reqID != "" || GetOperation(ctx) != nil {
 		if buf := GetBuffer(ctx); buf != nil {
 			attrs := make(map[string]string)
 			for _, a := range h.attrs {

--- a/handler.go
+++ b/handler.go
@@ -56,7 +56,9 @@ func (h *Handler) Handle(ctx context.Context, r slog.Record) error {
 		}
 	}
 
-	if reqID != "" || GetOperation(ctx) != nil {
+	op := GetOperation(ctx)
+
+	if reqID != "" || op != nil {
 		if buf := GetBuffer(ctx); buf != nil {
 			attrs := make(map[string]string)
 			for _, a := range h.attrs {
@@ -70,6 +72,10 @@ func (h *Handler) Handle(ctx context.Context, r slog.Record) error {
 				}
 				return true
 			})
+			if op != nil {
+				// Context operation ID is authoritative over any record attr.
+				attrs["operation_id"] = op.ID()
+			}
 			var entryAttrs map[string]string
 			if len(attrs) > 0 {
 				entryAttrs = attrs

--- a/operation.go
+++ b/operation.go
@@ -1,0 +1,143 @@
+package promolog
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrNoOperation is returned by PromoteOperation when the context carries no
+// operation started by StartOperation.
+var ErrNoOperation = errors.New("promolog: no operation in context")
+
+// TraceKindOperation marks a Trace produced by a detached operation rather than
+// an HTTP request. Request traces leave Trace.Kind empty.
+const TraceKindOperation = "operation"
+
+// Operation status values recorded on a promoted operation Trace.
+const (
+	OperationStatusOK     = "ok"
+	OperationStatusFailed = "failed"
+)
+
+// OperationAttr is a key/value pair attached to an operation at start time.
+// Build one with Attr.
+type OperationAttr struct {
+	Key   string
+	Value string
+}
+
+// Attr builds an OperationAttr for StartOperation.
+func Attr(key, value string) OperationAttr {
+	return OperationAttr{Key: key, Value: value}
+}
+
+type operationKeyType struct{}
+
+var operationKey = operationKeyType{}
+
+// Operation is a handle to a detached unit of background work. Its logs are
+// buffered for promote-on-error independent of the HTTP request that started
+// it. Create one with StartOperation and persist it with PromoteOperation.
+type Operation struct {
+	id              string
+	name            string
+	originRequestID string
+	parentRequestID string
+	attrs           map[string]string
+	buf             *Buffer
+	startedAt       time.Time
+}
+
+// ID returns the operation's unique ID.
+func (o *Operation) ID() string { return o.id }
+
+// Name returns the operation name supplied at StartOperation.
+func (o *Operation) Name() string { return o.name }
+
+// StartOperation begins a detached operation derived from ctx and returns a
+// context carrying the operation plus a handle to it. The returned context
+// holds a log buffer keyed to the operation, so records logged through a
+// promolog Handler are captured even after the caller detaches request
+// cancellation with context.WithoutCancel.
+//
+// When ctx carries a request ID (set by CorrelationMiddleware), it is preserved
+// as the operation's originating request ID for correlation. StartOperation
+// does not detach cancellation; apply context.WithoutCancel to the returned
+// context before handing it to work that must outlive the request.
+func StartOperation(ctx context.Context, name string, attrs ...OperationAttr) (context.Context, *Operation) {
+	op := &Operation{
+		id:              generateID(),
+		name:            name,
+		originRequestID: GetRequestID(ctx),
+		parentRequestID: GetParentRequestID(ctx),
+		buf:             &Buffer{},
+		startedAt:       time.Now(),
+	}
+	if len(attrs) > 0 {
+		op.attrs = make(map[string]string, len(attrs))
+		for _, a := range attrs {
+			op.attrs[a.Key] = a.Value
+		}
+	}
+	ctx = context.WithValue(ctx, operationKey, op)
+	ctx = context.WithValue(ctx, bufferKey{}, op.buf)
+	return ctx, op
+}
+
+// GetOperation returns the Operation stored in ctx by StartOperation, or nil.
+func GetOperation(ctx context.Context) *Operation {
+	op, _ := ctx.Value(operationKey).(*Operation)
+	return op
+}
+
+// trace builds the Trace persisted by PromoteOperation. A nil err records a
+// successful operation rather than skipping promotion.
+func (o *Operation) trace(err error, now time.Time) Trace {
+	tags := o.buf.Tags()
+	if len(o.attrs) > 0 {
+		if tags == nil {
+			tags = make(map[string]string, len(o.attrs))
+		}
+		for k, v := range o.attrs {
+			if _, ok := tags[k]; !ok {
+				tags[k] = v
+			}
+		}
+	}
+
+	status := OperationStatusOK
+	var errChain string
+	if err != nil {
+		status = OperationStatusFailed
+		errChain = err.Error()
+	}
+
+	return Trace{
+		RequestID:       o.id,
+		ParentRequestID: o.parentRequestID,
+		Kind:            TraceKindOperation,
+		OperationID:     o.id,
+		OperationName:   o.name,
+		OriginRequestID: o.originRequestID,
+		Status:          status,
+		ErrorChain:      errChain,
+		Tags:            tags,
+		Entries:         o.buf.Entries(),
+		StartedAt:       o.startedAt,
+		Duration:        now.Sub(o.startedAt),
+		CreatedAt:       now,
+	}
+}
+
+// PromoteOperation persists the operation carried by ctx to store, recording
+// err as the terminal error when non-nil. The store is passed explicitly
+// because the core package keeps no global store. It returns ErrNoOperation
+// when ctx carries no operation.
+func PromoteOperation(ctx context.Context, store Storer, err error) error {
+	op := GetOperation(ctx)
+	if op == nil {
+		return ErrNoOperation
+	}
+	return store.Promote(ctx, op.trace(err, time.Now()))
+}

--- a/operation_test.go
+++ b/operation_test.go
@@ -1,0 +1,112 @@
+package promolog
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartOperation_PreservesRequestCorrelation(t *testing.T) {
+	ctx := context.WithValue(context.Background(), RequestIDKey, "req-99")
+	ctx = context.WithValue(ctx, parentRequestIDKey, "req-parent")
+
+	_, op := StartOperation(ctx, "sales-goals-sync", Attr("trigger", "manual"))
+
+	assert.NotEmpty(t, op.ID())
+	assert.Equal(t, "sales-goals-sync", op.Name())
+	assert.Equal(t, "req-99", op.originRequestID)
+	assert.Equal(t, "req-parent", op.parentRequestID)
+}
+
+func TestStartOperation_CapturesLogsAfterCancellationDetached(t *testing.T) {
+	logger := slog.New(NewHandler(&discardHandler{}))
+
+	reqCtx := context.WithValue(context.Background(), RequestIDKey, "req-1")
+	reqCtx, cancel := context.WithCancel(reqCtx)
+
+	opCtx, op := StartOperation(reqCtx, "sync-job")
+	detached := context.WithoutCancel(opCtx)
+
+	// The originating HTTP request finishes and its context is cancelled.
+	cancel()
+
+	logger.InfoContext(detached, "background work started", "step", "1")
+	logger.ErrorContext(detached, "background work failed")
+
+	entries := op.buf.Entries()
+	require.Len(t, entries, 2)
+	assert.Equal(t, "background work started", entries[0].Message)
+	assert.Equal(t, "1", entries[0].Attrs["step"])
+	assert.Equal(t, "background work failed", entries[1].Message)
+}
+
+func TestStartOperation_CapturesLogsWithoutRequestContext(t *testing.T) {
+	logger := slog.New(NewHandler(&discardHandler{}))
+
+	opCtx, op := StartOperation(context.Background(), "cron-job")
+	logger.InfoContext(opCtx, "tick")
+
+	require.Len(t, op.buf.Entries(), 1)
+	assert.Empty(t, op.originRequestID)
+}
+
+func TestPromoteOperation_BuildsFailedOperationTrace(t *testing.T) {
+	store := &mockStorer{}
+	logger := slog.New(NewHandler(&discardHandler{}))
+
+	reqCtx := context.WithValue(context.Background(), RequestIDKey, "req-99")
+	opCtx, op := StartOperation(reqCtx, "sales-goals-sync", Attr("trigger", "manual"))
+	detached := context.WithoutCancel(opCtx)
+	logger.InfoContext(detached, "starting sync")
+
+	require.NoError(t, PromoteOperation(detached, store, errors.New("upstream 500")))
+
+	traces := store.promoted()
+	require.Len(t, traces, 1)
+	tr := traces[0]
+	assert.Equal(t, TraceKindOperation, tr.Kind)
+	assert.Equal(t, op.ID(), tr.OperationID)
+	assert.Equal(t, op.ID(), tr.RequestID)
+	assert.Equal(t, "sales-goals-sync", tr.OperationName)
+	assert.Equal(t, "req-99", tr.OriginRequestID)
+	assert.Equal(t, OperationStatusFailed, tr.Status)
+	assert.Equal(t, "upstream 500", tr.ErrorChain)
+	assert.Equal(t, "manual", tr.Tags["trigger"])
+	assert.GreaterOrEqual(t, tr.Duration, time.Duration(0))
+	require.Len(t, tr.Entries, 1)
+	assert.Equal(t, "starting sync", tr.Entries[0].Message)
+}
+
+func TestPromoteOperation_NilErrorRecordsOK(t *testing.T) {
+	store := &mockStorer{}
+	opCtx, _ := StartOperation(context.Background(), "cron-job")
+
+	require.NoError(t, PromoteOperation(opCtx, store, nil))
+
+	traces := store.promoted()
+	require.Len(t, traces, 1)
+	assert.Equal(t, OperationStatusOK, traces[0].Status)
+	assert.Empty(t, traces[0].ErrorChain)
+}
+
+func TestPromoteOperation_NoOperationInContext(t *testing.T) {
+	err := PromoteOperation(context.Background(), &mockStorer{}, nil)
+	assert.ErrorIs(t, err, ErrNoOperation)
+}
+
+func TestStartOperation_BufferTagsMergeWithAttrs(t *testing.T) {
+	store := &mockStorer{}
+	opCtx, _ := StartOperation(context.Background(), "job", Attr("trigger", "manual"))
+	GetBuffer(opCtx).Tag("tenant", "acme")
+
+	require.NoError(t, PromoteOperation(opCtx, store, nil))
+
+	tags := store.promoted()[0].Tags
+	assert.Equal(t, "manual", tags["trigger"])
+	assert.Equal(t, "acme", tags["tenant"])
+}

--- a/operation_test.go
+++ b/operation_test.go
@@ -55,6 +55,44 @@ func TestStartOperation_CapturesLogsWithoutRequestContext(t *testing.T) {
 	assert.Empty(t, op.originRequestID)
 }
 
+func TestStartOperation_CapturedEntriesCarryOperationID(t *testing.T) {
+	logger := slog.New(NewHandler(&discardHandler{}))
+
+	opCtx, op := StartOperation(context.Background(), "sync-job")
+	detached := context.WithoutCancel(opCtx)
+	logger.InfoContext(detached, "working", "step", "1")
+
+	entries := op.buf.Entries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, op.ID(), entries[0].Attrs["operation_id"])
+	assert.Equal(t, "1", entries[0].Attrs["step"])
+}
+
+func TestStartOperation_ContextOperationIDOverridesRecordAttr(t *testing.T) {
+	logger := slog.New(NewHandler(&discardHandler{}))
+
+	opCtx, op := StartOperation(context.Background(), "job")
+	logger.InfoContext(opCtx, "msg", "operation_id", "bogus")
+
+	entries := op.buf.Entries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, op.ID(), entries[0].Attrs["operation_id"])
+}
+
+func TestHandler_RequestEntriesHaveNoOperationID(t *testing.T) {
+	h := NewHandler(&discardHandler{})
+	ctx := context.WithValue(context.Background(), RequestIDKey, "req-1")
+	ctx = NewBufferContext(ctx)
+
+	rec := slog.NewRecord(time.Now(), slog.LevelInfo, "hi", 0)
+	require.NoError(t, h.Handle(ctx, rec))
+
+	entries := GetBuffer(ctx).Entries()
+	require.Len(t, entries, 1)
+	_, hasOpID := entries[0].Attrs["operation_id"]
+	assert.False(t, hasOpID)
+}
+
 func TestPromoteOperation_BuildsFailedOperationTrace(t *testing.T) {
 	store := &mockStorer{}
 	logger := slog.New(NewHandler(&discardHandler{}))

--- a/promolog.go
+++ b/promolog.go
@@ -28,9 +28,9 @@ var parentRequestIDKey = parentRequestIDKeyType{}
 
 // Entry is a single captured log record.
 type Entry struct {
-	Time    time.Time `json:"time"`
-	Level   string    `json:"level"`
-	Message string    `json:"msg"`
+	Time    time.Time         `json:"time"`
+	Level   string            `json:"level"`
+	Message string            `json:"msg"`
 	Attrs   map[string]string `json:"attrs,omitempty"`
 }
 
@@ -41,13 +41,13 @@ type Entry struct {
 // half of entries. Middle entries are dropped and replaced with a synthetic
 // entry indicating how many were elided. A limit of 0 means unlimited.
 type Buffer struct {
-	mu      sync.Mutex
-	entries []Entry
-	limit   int // 0 = unlimited
-	head    []Entry
-	tail    []Entry
-	total   int // total entries appended (only tracked when limit > 0)
-	elided  int // entries dropped from the middle
+	mu           sync.Mutex
+	entries      []Entry
+	limit        int // 0 = unlimited
+	head         []Entry
+	tail         []Entry
+	total        int // total entries appended (only tracked when limit > 0)
+	elided       int // entries dropped from the middle
 	tags         map[string]string
 	requestBody  string
 	responseBody string
@@ -209,6 +209,12 @@ func GetBuffer(ctx context.Context) *Buffer {
 
 // Trace contains all the information captured when a request is promoted.
 // ErrorChain is optional and may be empty for non-error promotions.
+//
+// The operation fields (Kind, OperationID, OperationName, OriginRequestID,
+// Status, StartedAt, Duration) are populated only for detached operation
+// traces created via StartOperation/PromoteOperation; request traces leave
+// them empty. For an operation trace, RequestID holds the operation ID so a
+// single store keys every trace the same way.
 type Trace struct {
 	RequestID       string
 	ParentRequestID string `json:"parent_request_id,omitempty"`
@@ -224,6 +230,14 @@ type Trace struct {
 	RequestBody     string `json:"request_body,omitempty"`
 	ResponseBody    string `json:"response_body,omitempty"`
 	CreatedAt       time.Time
+
+	Kind            string        `json:"kind,omitempty"`
+	OperationID     string        `json:"operation_id,omitempty"`
+	OperationName   string        `json:"operation_name,omitempty"`
+	OriginRequestID string        `json:"origin_request_id,omitempty"`
+	Status          string        `json:"status,omitempty"`
+	StartedAt       time.Time     `json:"started_at,omitzero"`
+	Duration        time.Duration `json:"duration,omitempty"`
 }
 
 // TraceSummary is a lightweight row for list views (no log entries).
@@ -238,6 +252,14 @@ type TraceSummary struct {
 	UserID          string
 	Tags            map[string]string
 	CreatedAt       time.Time
+
+	Kind            string        `json:"kind,omitempty"`
+	OperationID     string        `json:"operation_id,omitempty"`
+	OperationName   string        `json:"operation_name,omitempty"`
+	OriginRequestID string        `json:"origin_request_id,omitempty"`
+	Status          string        `json:"status,omitempty"`
+	StartedAt       time.Time     `json:"started_at,omitzero"`
+	Duration        time.Duration `json:"duration,omitempty"`
 }
 
 // TraceFilter holds all filter parameters for ListTraces.
@@ -268,8 +290,8 @@ type FilterOptions struct {
 type RetentionRule struct {
 	ID        int       `json:"id"`
 	Name      string    `json:"name"`
-	Field     string    `json:"field"`     // "route", "status_code", "method", etc.
-	Operator  string    `json:"operator"`  // "equals", "contains", "starts_with", "matches_glob"
+	Field     string    `json:"field"`    // "route", "status_code", "method", etc.
+	Operator  string    `json:"operator"` // "equals", "contains", "starts_with", "matches_glob"
 	Value     string    `json:"value"`
 	TTLHours  int       `json:"ttl_hours"` // retention period in hours
 	Enabled   bool      `json:"enabled"`

--- a/sqlite/operation_test.go
+++ b/sqlite/operation_test.go
@@ -1,0 +1,135 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/catgoose/promolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sampleOperationTrace(opID string) promolog.Trace {
+	now := time.Now()
+	return promolog.Trace{
+		RequestID:       opID,
+		Kind:            promolog.TraceKindOperation,
+		OperationID:     opID,
+		OperationName:   "sales-goals-sync",
+		OriginRequestID: "req-origin",
+		ParentRequestID: "req-parent",
+		Status:          promolog.OperationStatusFailed,
+		ErrorChain:      "upstream timeout",
+		Tags:            map[string]string{"trigger": "manual"},
+		Entries: []promolog.Entry{
+			{Time: now, Level: "ERROR", Message: "sync failed"},
+		},
+		StartedAt: now.Add(-2 * time.Second),
+		Duration:  2 * time.Second,
+	}
+}
+
+func TestPromoteOperation_Roundtrip(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	tr := sampleOperationTrace("op-1")
+	require.NoError(t, store.Promote(ctx, tr))
+
+	got, err := store.Get(ctx, "op-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	assert.Equal(t, promolog.TraceKindOperation, got.Kind)
+	assert.Equal(t, "op-1", got.OperationID)
+	assert.Equal(t, "sales-goals-sync", got.OperationName)
+	assert.Equal(t, "req-origin", got.OriginRequestID)
+	assert.Equal(t, "req-parent", got.ParentRequestID)
+	assert.Equal(t, promolog.OperationStatusFailed, got.Status)
+	assert.Equal(t, "upstream timeout", got.ErrorChain)
+	assert.Equal(t, "manual", got.Tags["trigger"])
+	assert.Equal(t, 2*time.Second, got.Duration)
+	assert.WithinDuration(t, tr.StartedAt, got.StartedAt, time.Second)
+	require.Len(t, got.Entries, 1)
+	assert.Equal(t, "sync failed", got.Entries[0].Message)
+}
+
+func TestPromoteOperation_DuplicateOperationID(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, store.Promote(ctx, sampleOperationTrace("op-dup")))
+
+	err := store.Promote(ctx, sampleOperationTrace("op-dup"))
+	assert.True(t, errors.Is(err, promolog.ErrDuplicateTrace))
+}
+
+func TestListTraces_DistinguishesOperationFromRequest(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, store.Promote(ctx, sampleTrace("req-1", 500, "GET")))
+	require.NoError(t, store.Promote(ctx, sampleOperationTrace("op-1")))
+
+	rows, total, err := store.ListTraces(ctx, promolog.TraceFilter{Page: 1, PerPage: 10})
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+
+	byID := make(map[string]promolog.TraceSummary, len(rows))
+	for _, r := range rows {
+		byID[r.RequestID] = r
+	}
+
+	op := byID["op-1"]
+	assert.Equal(t, promolog.TraceKindOperation, op.Kind)
+	assert.Equal(t, "op-1", op.OperationID)
+	assert.Equal(t, "sales-goals-sync", op.OperationName)
+	assert.Equal(t, "req-origin", op.OriginRequestID)
+	assert.Equal(t, promolog.OperationStatusFailed, op.Status)
+
+	req := byID["req-1"]
+	assert.Empty(t, req.Kind)
+	assert.Empty(t, req.OperationID)
+}
+
+func TestEnsureSchema_MigratesLegacyTable(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	legacy := `CREATE TABLE error_traces (
+		id          INTEGER PRIMARY KEY AUTOINCREMENT,
+		request_id  VARCHAR(64) NOT NULL UNIQUE,
+		error_chain TEXT NOT NULL,
+		status_code INT NOT NULL,
+		route       VARCHAR(500) NOT NULL,
+		method      VARCHAR(10) NOT NULL,
+		user_agent  TEXT,
+		remote_ip   VARCHAR(45),
+		user_id     VARCHAR(255),
+		entries     TEXT NOT NULL,
+		created_at  TIMESTAMP NOT NULL
+	)`
+	_, err := db.Exec(legacy)
+	require.NoError(t, err)
+	_, err = db.Exec(
+		`INSERT INTO error_traces (request_id, error_chain, status_code, route, method, user_agent, remote_ip, user_id, entries, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"legacy-1", "boom", 500, "/old", "GET", "", "", "", "[]", time.Now(),
+	)
+	require.NoError(t, err)
+
+	store := NewStore(db)
+	require.NoError(t, store.EnsureSchema())
+
+	got, err := store.Get(ctx, "legacy-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "boom", got.ErrorChain)
+	assert.Empty(t, got.Kind)
+
+	require.NoError(t, store.Promote(ctx, sampleOperationTrace("op-after-migrate")))
+	op, err := store.Get(ctx, "op-after-migrate")
+	require.NoError(t, err)
+	require.NotNil(t, op)
+	assert.Equal(t, promolog.TraceKindOperation, op.Kind)
+	assert.Equal(t, "sales-goals-sync", op.OperationName)
+}

--- a/sqlite/store.go
+++ b/sqlite/store.go
@@ -26,16 +26,38 @@ const schema = `CREATE TABLE IF NOT EXISTS error_traces (
 	user_id           VARCHAR(255),
 	entries           TEXT NOT NULL,
 	tags              TEXT,
+	kind              TEXT,
+	operation_name    TEXT,
+	origin_request_id VARCHAR(64),
+	status            TEXT,
+	started_at        TIMESTAMP,
+	duration_ms       INTEGER,
 	created_at        TIMESTAMP NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_error_traces_request_id ON error_traces(request_id);
 CREATE INDEX IF NOT EXISTS idx_error_traces_created_at ON error_traces(created_at);`
 
-const migrateAddTags = `ALTER TABLE error_traces ADD COLUMN tags TEXT`
-const migrateAddRequestBody = `ALTER TABLE error_traces ADD COLUMN request_body TEXT`
-const migrateAddResponseBody = `ALTER TABLE error_traces ADD COLUMN response_body TEXT`
-const migrateAddParentRequestID = `ALTER TABLE error_traces ADD COLUMN parent_request_id VARCHAR(64)`
-const migrateAddParentRequestIDIndex = `CREATE INDEX IF NOT EXISTS idx_error_traces_parent_request_id ON error_traces(parent_request_id)`
+// addColumnMigrations bring an existing error_traces table up to the current
+// column set. Re-running them is harmless: SQLite reports a "duplicate column"
+// error when the column already exists, which EnsureSchema ignores.
+var addColumnMigrations = []string{
+	`ALTER TABLE error_traces ADD COLUMN tags TEXT`,
+	`ALTER TABLE error_traces ADD COLUMN request_body TEXT`,
+	`ALTER TABLE error_traces ADD COLUMN response_body TEXT`,
+	`ALTER TABLE error_traces ADD COLUMN parent_request_id VARCHAR(64)`,
+	`ALTER TABLE error_traces ADD COLUMN kind TEXT`,
+	`ALTER TABLE error_traces ADD COLUMN operation_name TEXT`,
+	`ALTER TABLE error_traces ADD COLUMN origin_request_id VARCHAR(64)`,
+	`ALTER TABLE error_traces ADD COLUMN status TEXT`,
+	`ALTER TABLE error_traces ADD COLUMN started_at TIMESTAMP`,
+	`ALTER TABLE error_traces ADD COLUMN duration_ms INTEGER`,
+}
+
+var indexMigrations = []string{
+	`CREATE INDEX IF NOT EXISTS idx_error_traces_parent_request_id ON error_traces(parent_request_id)`,
+	`CREATE INDEX IF NOT EXISTS idx_error_traces_kind ON error_traces(kind)`,
+	`CREATE INDEX IF NOT EXISTS idx_error_traces_origin_request_id ON error_traces(origin_request_id)`,
+}
 
 const retentionRulesSchema = `CREATE TABLE IF NOT EXISTS retention_rules (
 	id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -80,34 +102,17 @@ func (s *Store) EnsureSchema() error {
 	if _, err := s.db.Exec(schema); err != nil {
 		return err
 	}
-	// Migration: add tags column if missing (existing databases).
-	// ALTER TABLE ... ADD COLUMN is a no-op error when the column exists.
-	if _, err := s.db.Exec(migrateAddTags); err != nil {
-		// Ignore "duplicate column" errors — the column already exists.
-		if !strings.Contains(err.Error(), "duplicate column") {
-			return err
+	for _, stmt := range addColumnMigrations {
+		if _, err := s.db.Exec(stmt); err != nil {
+			if !strings.Contains(err.Error(), "duplicate column") {
+				return err
+			}
 		}
 	}
-	// Migration: add request_body column if missing.
-	if _, err := s.db.Exec(migrateAddRequestBody); err != nil {
-		if !strings.Contains(err.Error(), "duplicate column") {
+	for _, stmt := range indexMigrations {
+		if _, err := s.db.Exec(stmt); err != nil {
 			return err
 		}
-	}
-	// Migration: add response_body column if missing.
-	if _, err := s.db.Exec(migrateAddResponseBody); err != nil {
-		if !strings.Contains(err.Error(), "duplicate column") {
-			return err
-		}
-	}
-	// Migration: add parent_request_id column if missing.
-	if _, err := s.db.Exec(migrateAddParentRequestID); err != nil {
-		if !strings.Contains(err.Error(), "duplicate column") {
-			return err
-		}
-	}
-	if _, err := s.db.Exec(migrateAddParentRequestIDIndex); err != nil {
-		return err
 	}
 	if _, err := s.db.Exec(filterRulesSchema); err != nil {
 		return err
@@ -158,14 +163,29 @@ func (s *Store) promoteAt(ctx context.Context, trace promolog.Trace, createdAt t
 	if trace.ParentRequestID != "" {
 		parentID = &trace.ParentRequestID
 	}
+	kind := nullableString(trace.Kind)
+	opName := nullableString(trace.OperationName)
+	originID := nullableString(trace.OriginRequestID)
+	status := nullableString(trace.Status)
+	var startedAt *time.Time
+	if !trace.StartedAt.IsZero() {
+		t := trace.StartedAt.UTC()
+		startedAt = &t
+	}
+	var durationMS *int64
+	if trace.Duration > 0 {
+		d := trace.Duration.Milliseconds()
+		durationMS = &d
+	}
 	res, err := s.db.ExecContext(ctx,
 		`INSERT OR IGNORE INTO error_traces
-			(request_id, parent_request_id, error_chain, status_code, route, method, user_agent, remote_ip, user_id, entries, tags, request_body, response_body, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			(request_id, parent_request_id, error_chain, status_code, route, method, user_agent, remote_ip, user_id, entries, tags, request_body, response_body, kind, operation_name, origin_request_id, status, started_at, duration_ms, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		trace.RequestID, parentID, trace.ErrorChain, trace.StatusCode,
 		trace.Route, trace.Method, trace.UserAgent,
 		trace.RemoteIP, trace.UserID, string(data),
-		tagsJSON, reqBody, respBody, createdAt,
+		tagsJSON, reqBody, respBody,
+		kind, opName, originID, status, startedAt, durationMS, createdAt,
 	)
 	if err != nil {
 		return fmt.Errorf("insert trace: %w", err)
@@ -186,23 +206,41 @@ func (s *Store) promoteAt(ctx context.Context, trace promolog.Trace, createdAt t
 			UserID:          trace.UserID,
 			Tags:            trace.Tags,
 			CreatedAt:       createdAt,
+			Kind:            trace.Kind,
+			OperationID:     trace.OperationID,
+			OperationName:   trace.OperationName,
+			OriginRequestID: trace.OriginRequestID,
+			Status:          trace.Status,
+			StartedAt:       trace.StartedAt,
+			Duration:        trace.Duration,
 		})
 	}
 	return nil
 }
 
+// nullableString returns nil for an empty string so the column stores NULL.
+func nullableString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
 // Get returns the full trace for a request ID, or nil if not found.
 func (s *Store) Get(ctx context.Context, requestID string) (*promolog.Trace, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT request_id, parent_request_id, error_chain, status_code, route, method, user_agent, remote_ip, user_id, entries, tags, request_body, response_body, created_at
+		`SELECT request_id, parent_request_id, error_chain, status_code, route, method, user_agent, remote_ip, user_id, entries, tags, request_body, response_body, kind, operation_name, origin_request_id, status, started_at, duration_ms, created_at
 		FROM error_traces WHERE request_id = ?`, requestID)
 
 	var t promolog.Trace
 	var entriesJSON string
 	var tagsJSON, reqBody, respBody sql.NullString
-	var parentID sql.NullString
+	var parentID, kind, opName, originID, status sql.NullString
+	var startedAt sql.NullTime
+	var durationMS sql.NullInt64
 	err := row.Scan(&t.RequestID, &parentID, &t.ErrorChain, &t.StatusCode, &t.Route,
-		&t.Method, &t.UserAgent, &t.RemoteIP, &t.UserID, &entriesJSON, &tagsJSON, &reqBody, &respBody, &t.CreatedAt)
+		&t.Method, &t.UserAgent, &t.RemoteIP, &t.UserID, &entriesJSON, &tagsJSON, &reqBody, &respBody,
+		&kind, &opName, &originID, &status, &startedAt, &durationMS, &t.CreatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -226,7 +264,42 @@ func (s *Store) Get(ctx context.Context, requestID string) (*promolog.Trace, err
 	if respBody.Valid {
 		t.ResponseBody = respBody.String
 	}
+	applyOperationFields(&t.Kind, &t.OperationID, &t.OperationName, &t.OriginRequestID,
+		&t.Status, &t.StartedAt, &t.Duration, t.RequestID, kind, opName, originID, status, startedAt, durationMS)
 	return &t, nil
+}
+
+// applyOperationFields copies the operation columns scanned from a row into the
+// destination trace fields. For an operation row, operationID mirrors the
+// request_id key so callers always have the operation's ID alongside Kind.
+func applyOperationFields(
+	dstKind, dstOperationID, dstOperationName, dstOriginID, dstStatus *string,
+	dstStartedAt *time.Time, dstDuration *time.Duration,
+	requestID string,
+	kind, opName, originID, status sql.NullString,
+	startedAt sql.NullTime, durationMS sql.NullInt64,
+) {
+	if kind.Valid {
+		*dstKind = kind.String
+	}
+	if opName.Valid {
+		*dstOperationName = opName.String
+	}
+	if originID.Valid {
+		*dstOriginID = originID.String
+	}
+	if status.Valid {
+		*dstStatus = status.String
+	}
+	if startedAt.Valid {
+		*dstStartedAt = startedAt.Time
+	}
+	if durationMS.Valid {
+		*dstDuration = time.Duration(durationMS.Int64) * time.Millisecond
+	}
+	if *dstKind == promolog.TraceKindOperation {
+		*dstOperationID = requestID
+	}
 }
 
 // ListTraces returns a page of trace summaries matching the given filters.
@@ -263,7 +336,7 @@ func (s *Store) ListTraces(ctx context.Context, f promolog.TraceFilter) ([]promo
 
 	offset := (f.Page - 1) * f.PerPage
 	dataQ := fmt.Sprintf(
-		`SELECT request_id, parent_request_id, error_chain, status_code, route, method, remote_ip, user_id, tags, created_at
+		`SELECT request_id, parent_request_id, error_chain, status_code, route, method, remote_ip, user_id, tags, kind, operation_name, origin_request_id, status, started_at, duration_ms, created_at
 		FROM error_traces%s ORDER BY %s %s LIMIT ? OFFSET ?`,
 		where, orderCol, orderDir)
 	// Use a new slice to avoid aliasing the args backing array.
@@ -281,9 +354,12 @@ func (s *Store) ListTraces(ctx context.Context, f promolog.TraceFilter) ([]promo
 	for rows.Next() {
 		var ts promolog.TraceSummary
 		var tagsJSON sql.NullString
-		var pID sql.NullString
+		var pID, kind, opName, originID, status sql.NullString
+		var startedAt sql.NullTime
+		var durationMS sql.NullInt64
 		if err := rows.Scan(&ts.RequestID, &pID, &ts.ErrorChain, &ts.StatusCode,
-			&ts.Route, &ts.Method, &ts.RemoteIP, &ts.UserID, &tagsJSON, &ts.CreatedAt); err != nil {
+			&ts.Route, &ts.Method, &ts.RemoteIP, &ts.UserID, &tagsJSON,
+			&kind, &opName, &originID, &status, &startedAt, &durationMS, &ts.CreatedAt); err != nil {
 			return nil, 0, err
 		}
 		if pID.Valid {
@@ -292,6 +368,8 @@ func (s *Store) ListTraces(ctx context.Context, f promolog.TraceFilter) ([]promo
 		if tagsJSON.Valid && tagsJSON.String != "" {
 			_ = json.Unmarshal([]byte(tagsJSON.String), &ts.Tags)
 		}
+		applyOperationFields(&ts.Kind, &ts.OperationID, &ts.OperationName, &ts.OriginRequestID,
+			&ts.Status, &ts.StartedAt, &ts.Duration, ts.RequestID, kind, opName, originID, status, startedAt, durationMS)
 		result = append(result, ts)
 	}
 	return result, total, rows.Err()


### PR DESCRIPTION
Closes #60

## Summary

Adds first-class support for promoted **operation traces** — background work that can fail after the originating HTTP request has already returned (sync jobs, queue consumers, fire-and-forget goroutines).

## API

- `StartOperation(ctx, name, ...Attr) (context.Context, *Operation)` — begins a detached operation with its own log buffer, preserving the originating request ID for correlation.
- `PromoteOperation(ctx, store, err)` — persists the context's operation; a nil `err` records success, a non-nil `err` records the terminal error chain and a failed status. The store is explicit (the core package keeps no global store).
- `Attr(key, value)` — operation attribute, stored as trace tags.
- `Operation` handle exposes `ID()` / `Name()`; `ErrNoOperation` sentinel.

Cancellation is never silently kept: `StartOperation` does not detach: callers apply `context.WithoutCancel` to the returned context before handing it to work that must outlive the request. The operation's log buffer survives that detach, so a promolog `Handler` keeps capturing records.

## Storage & model

- `Trace`/`TraceSummary` gain optional fields: `Kind`, `OperationID`, `OperationName`, `OriginRequestID`, `Status`, `StartedAt`, `Duration`. Request traces leave them empty.
- Operation traces reuse the single `error_traces` table; the `request_id` column holds the operation ID (so duplicate detection, `Get`, and `DeleteTrace` work unchanged), with `kind` discriminating the two. New columns and indexes are added through additive migrations — old databases migrate cleanly via `EnsureSchema`.
- JSON and webhook exporters emit the new fields (`omitempty`) only for operation traces; request-trace payloads are unchanged.

## Tests

- Detached-context log capture after request cancellation; capture without any request context.
- Promotion builds correct operation trace (kind, IDs, status, error chain, duration, merged attrs/tags); nil-error success path; `ErrNoOperation`.
- SQLite round trip, duplicate operation ID, list distinguishes operation vs request, legacy-table migration.
- Exporters include operation fields and omit them for request traces.

`make ci` (vet + `-race` tests, both modules) passes; `golangci-lint` clean.

## Notes

- No admin/UI surface (out of scope); the data is shaped so a UI can filter request vs operation traces by `Kind`.
- Operation rows have empty route/method and `status_code` 0, so they can appear in request-oriented filter/aggregate distinct values. Left as-is per the plan's non-goal of not redesigning filtering; a UI can filter by `Kind`.